### PR TITLE
[#3340] Deployment ARM templates update (function-template-with-preexisting-rg) - composer-samples

### DIFF
--- a/composer-samples/csharp_dotnetcore/projects/AskingQuestionsSample/AskingQuestionsSample/scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
+++ b/composer-samples/csharp_dotnetcore/projects/AskingQuestionsSample/AskingQuestionsSample/scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
@@ -249,23 +249,24 @@
       "condition": "[parameters('useCosmosDb')]"
     },
     {
-      "apiVersion": "2017-12-01",
+      "apiVersion": "2021-03-01",
       "type": "Microsoft.BotService/botServices",
       "name": "[parameters('botId')]",
       "location": "global",
-      "kind": "bot",
+      "kind": "azurebot",
       "sku": {
         "name": "[parameters('botSku')]"
       },
       "properties": {
         "name": "[parameters('botId')]",
         "displayName": "[parameters('botId')]",
+        "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
         "endpoint": "[variables('botEndpoint')]",
         "msaAppId": "[parameters('appId')]",
-        "developerAppInsightsApplicationId": null,
-        "developerAppInsightKey": null,
-        "publishingCredentials": null,
-        "storageResourceId": null
+        "luisAppIds": [],
+        "schemaTransformationVersion": "1.3",
+        "isCmekEnabled": false,
+        "isIsolated": false
       },
       "dependsOn": [
         "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/composer-samples/csharp_dotnetcore/projects/ControllingConversationFlowSample/ControllingConversationFlowSample/scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
+++ b/composer-samples/csharp_dotnetcore/projects/ControllingConversationFlowSample/ControllingConversationFlowSample/scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
@@ -249,23 +249,24 @@
       "condition": "[parameters('useCosmosDb')]"
     },
     {
-      "apiVersion": "2017-12-01",
+      "apiVersion": "2021-03-01",
       "type": "Microsoft.BotService/botServices",
       "name": "[parameters('botId')]",
       "location": "global",
-      "kind": "bot",
+      "kind": "azurebot",
       "sku": {
         "name": "[parameters('botSku')]"
       },
       "properties": {
         "name": "[parameters('botId')]",
         "displayName": "[parameters('botId')]",
+        "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
         "endpoint": "[variables('botEndpoint')]",
         "msaAppId": "[parameters('appId')]",
-        "developerAppInsightsApplicationId": null,
-        "developerAppInsightKey": null,
-        "publishingCredentials": null,
-        "storageResourceId": null
+        "luisAppIds": [],
+        "schemaTransformationVersion": "1.3",
+        "isCmekEnabled": false,
+        "isIsolated": false
       },
       "dependsOn": [
         "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/composer-samples/csharp_dotnetcore/projects/CustomAction/CustomAction/scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
+++ b/composer-samples/csharp_dotnetcore/projects/CustomAction/CustomAction/scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
@@ -249,23 +249,24 @@
       "condition": "[parameters('useCosmosDb')]"
     },
     {
-      "apiVersion": "2017-12-01",
+      "apiVersion": "2021-03-01",
       "type": "Microsoft.BotService/botServices",
       "name": "[parameters('botId')]",
       "location": "global",
-      "kind": "bot",
+      "kind": "azurebot",
       "sku": {
         "name": "[parameters('botSku')]"
       },
       "properties": {
         "name": "[parameters('botId')]",
         "displayName": "[parameters('botId')]",
+        "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
         "endpoint": "[variables('botEndpoint')]",
         "msaAppId": "[parameters('appId')]",
-        "developerAppInsightsApplicationId": null,
-        "developerAppInsightKey": null,
-        "publishingCredentials": null,
-        "storageResourceId": null
+        "luisAppIds": [],
+        "schemaTransformationVersion": "1.3",
+        "isCmekEnabled": false,
+        "isIsolated": false
       },
       "dependsOn": [
         "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/composer-samples/csharp_dotnetcore/projects/CustomTrigger/CustomTrigger/scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
+++ b/composer-samples/csharp_dotnetcore/projects/CustomTrigger/CustomTrigger/scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
@@ -249,23 +249,24 @@
       "condition": "[parameters('useCosmosDb')]"
     },
     {
-      "apiVersion": "2017-12-01",
+      "apiVersion": "2021-03-01",
       "type": "Microsoft.BotService/botServices",
       "name": "[parameters('botId')]",
       "location": "global",
-      "kind": "bot",
+      "kind": "azurebot",
       "sku": {
         "name": "[parameters('botSku')]"
       },
       "properties": {
         "name": "[parameters('botId')]",
         "displayName": "[parameters('botId')]",
+        "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
         "endpoint": "[variables('botEndpoint')]",
         "msaAppId": "[parameters('appId')]",
-        "developerAppInsightsApplicationId": null,
-        "developerAppInsightKey": null,
-        "publishingCredentials": null,
-        "storageResourceId": null
+        "luisAppIds": [],
+        "schemaTransformationVersion": "1.3",
+        "isCmekEnabled": false,
+        "isIsolated": false
       },
       "dependsOn": [
         "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/composer-samples/csharp_dotnetcore/projects/EchoBot/EchoBot/scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
+++ b/composer-samples/csharp_dotnetcore/projects/EchoBot/EchoBot/scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
@@ -249,23 +249,24 @@
       "condition": "[parameters('useCosmosDb')]"
     },
     {
-      "apiVersion": "2017-12-01",
+      "apiVersion": "2021-03-01",
       "type": "Microsoft.BotService/botServices",
       "name": "[parameters('botId')]",
       "location": "global",
-      "kind": "bot",
+      "kind": "azurebot",
       "sku": {
         "name": "[parameters('botSku')]"
       },
       "properties": {
         "name": "[parameters('botId')]",
         "displayName": "[parameters('botId')]",
+        "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
         "endpoint": "[variables('botEndpoint')]",
         "msaAppId": "[parameters('appId')]",
-        "developerAppInsightsApplicationId": null,
-        "developerAppInsightKey": null,
-        "publishingCredentials": null,
-        "storageResourceId": null
+        "luisAppIds": [],
+        "schemaTransformationVersion": "1.3",
+        "isCmekEnabled": false,
+        "isIsolated": false
       },
       "dependsOn": [
         "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/composer-samples/csharp_dotnetcore/projects/InterruptionSample/InterruptionSample/scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
+++ b/composer-samples/csharp_dotnetcore/projects/InterruptionSample/InterruptionSample/scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
@@ -249,23 +249,24 @@
       "condition": "[parameters('useCosmosDb')]"
     },
     {
-      "apiVersion": "2017-12-01",
+      "apiVersion": "2021-03-01",
       "type": "Microsoft.BotService/botServices",
       "name": "[parameters('botId')]",
       "location": "global",
-      "kind": "bot",
+      "kind": "azurebot",
       "sku": {
         "name": "[parameters('botSku')]"
       },
       "properties": {
         "name": "[parameters('botId')]",
         "displayName": "[parameters('botId')]",
+        "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
         "endpoint": "[variables('botEndpoint')]",
         "msaAppId": "[parameters('appId')]",
-        "developerAppInsightsApplicationId": null,
-        "developerAppInsightKey": null,
-        "publishingCredentials": null,
-        "storageResourceId": null
+        "luisAppIds": [],
+        "schemaTransformationVersion": "1.3",
+        "isCmekEnabled": false,
+        "isIsolated": false
       },
       "dependsOn": [
         "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/composer-samples/csharp_dotnetcore/projects/OrchestratorDispatch/Scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
+++ b/composer-samples/csharp_dotnetcore/projects/OrchestratorDispatch/Scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
@@ -249,23 +249,24 @@
       "condition": "[parameters('useCosmosDb')]"
     },
     {
-      "apiVersion": "2017-12-01",
+      "apiVersion": "2021-03-01",
       "type": "Microsoft.BotService/botServices",
       "name": "[parameters('botId')]",
       "location": "global",
-      "kind": "bot",
+      "kind": "azurebot",
       "sku": {
         "name": "[parameters('botSku')]"
       },
       "properties": {
         "name": "[parameters('botId')]",
         "displayName": "[parameters('botId')]",
+        "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
         "endpoint": "[variables('botEndpoint')]",
         "msaAppId": "[parameters('appId')]",
-        "developerAppInsightsApplicationId": null,
-        "developerAppInsightKey": null,
-        "publishingCredentials": null,
-        "storageResourceId": null
+        "luisAppIds": [],
+        "schemaTransformationVersion": "1.3",
+        "isCmekEnabled": false,
+        "isIsolated": false
       },
       "dependsOn": [
         "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/composer-samples/csharp_dotnetcore/projects/OrchestratorSchoolNavigator/SchoolNavigator/Scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
+++ b/composer-samples/csharp_dotnetcore/projects/OrchestratorSchoolNavigator/SchoolNavigator/Scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
@@ -249,23 +249,24 @@
       "condition": "[parameters('useCosmosDb')]"
     },
     {
-      "apiVersion": "2017-12-01",
+      "apiVersion": "2021-03-01",
       "type": "Microsoft.BotService/botServices",
       "name": "[parameters('botId')]",
       "location": "global",
-      "kind": "bot",
+      "kind": "azurebot",
       "sku": {
         "name": "[parameters('botSku')]"
       },
       "properties": {
         "name": "[parameters('botId')]",
         "displayName": "[parameters('botId')]",
+        "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
         "endpoint": "[variables('botEndpoint')]",
         "msaAppId": "[parameters('appId')]",
-        "developerAppInsightsApplicationId": null,
-        "developerAppInsightKey": null,
-        "publishingCredentials": null,
-        "storageResourceId": null
+        "luisAppIds": [],
+        "schemaTransformationVersion": "1.3",
+        "isCmekEnabled": false,
+        "isIsolated": false
       },
       "dependsOn": [
         "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/composer-samples/csharp_dotnetcore/projects/QnAMakerLUISSample/QnAMakerLUISSample/scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
+++ b/composer-samples/csharp_dotnetcore/projects/QnAMakerLUISSample/QnAMakerLUISSample/scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
@@ -249,23 +249,24 @@
       "condition": "[parameters('useCosmosDb')]"
     },
     {
-      "apiVersion": "2017-12-01",
+      "apiVersion": "2021-03-01",
       "type": "Microsoft.BotService/botServices",
       "name": "[parameters('botId')]",
       "location": "global",
-      "kind": "bot",
+      "kind": "azurebot",
       "sku": {
         "name": "[parameters('botSku')]"
       },
       "properties": {
         "name": "[parameters('botId')]",
         "displayName": "[parameters('botId')]",
+        "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
         "endpoint": "[variables('botEndpoint')]",
         "msaAppId": "[parameters('appId')]",
-        "developerAppInsightsApplicationId": null,
-        "developerAppInsightKey": null,
-        "publishingCredentials": null,
-        "storageResourceId": null
+        "luisAppIds": [],
+        "schemaTransformationVersion": "1.3",
+        "isCmekEnabled": false,
+        "isIsolated": false
       },
       "dependsOn": [
         "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/composer-samples/csharp_dotnetcore/projects/QnASample/QnASample/scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
+++ b/composer-samples/csharp_dotnetcore/projects/QnASample/QnASample/scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
@@ -249,23 +249,24 @@
       "condition": "[parameters('useCosmosDb')]"
     },
     {
-      "apiVersion": "2017-12-01",
+      "apiVersion": "2021-03-01",
       "type": "Microsoft.BotService/botServices",
       "name": "[parameters('botId')]",
       "location": "global",
-      "kind": "bot",
+      "kind": "azurebot",
       "sku": {
         "name": "[parameters('botSku')]"
       },
       "properties": {
         "name": "[parameters('botId')]",
         "displayName": "[parameters('botId')]",
+        "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
         "endpoint": "[variables('botEndpoint')]",
         "msaAppId": "[parameters('appId')]",
-        "developerAppInsightsApplicationId": null,
-        "developerAppInsightKey": null,
-        "publishingCredentials": null,
-        "storageResourceId": null
+        "luisAppIds": [],
+        "schemaTransformationVersion": "1.3",
+        "isCmekEnabled": false,
+        "isIsolated": false
       },
       "dependsOn": [
         "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/composer-samples/csharp_dotnetcore/projects/RespondingWithCardsSample/RespondingWithCardsSample/scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
+++ b/composer-samples/csharp_dotnetcore/projects/RespondingWithCardsSample/RespondingWithCardsSample/scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
@@ -249,23 +249,24 @@
       "condition": "[parameters('useCosmosDb')]"
     },
     {
-      "apiVersion": "2017-12-01",
+      "apiVersion": "2021-03-01",
       "type": "Microsoft.BotService/botServices",
       "name": "[parameters('botId')]",
       "location": "global",
-      "kind": "bot",
+      "kind": "azurebot",
       "sku": {
         "name": "[parameters('botSku')]"
       },
       "properties": {
         "name": "[parameters('botId')]",
         "displayName": "[parameters('botId')]",
+        "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
         "endpoint": "[variables('botEndpoint')]",
         "msaAppId": "[parameters('appId')]",
-        "developerAppInsightsApplicationId": null,
-        "developerAppInsightKey": null,
-        "publishingCredentials": null,
-        "storageResourceId": null
+        "luisAppIds": [],
+        "schemaTransformationVersion": "1.3",
+        "isCmekEnabled": false,
+        "isIsolated": false
       },
       "dependsOn": [
         "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/composer-samples/csharp_dotnetcore/projects/RespondingWithTextSample/RespondingWithTextSample/scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
+++ b/composer-samples/csharp_dotnetcore/projects/RespondingWithTextSample/RespondingWithTextSample/scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
@@ -249,23 +249,24 @@
       "condition": "[parameters('useCosmosDb')]"
     },
     {
-      "apiVersion": "2017-12-01",
+      "apiVersion": "2021-03-01",
       "type": "Microsoft.BotService/botServices",
       "name": "[parameters('botId')]",
       "location": "global",
-      "kind": "bot",
+      "kind": "azurebot",
       "sku": {
         "name": "[parameters('botSku')]"
       },
       "properties": {
         "name": "[parameters('botId')]",
         "displayName": "[parameters('botId')]",
+        "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
         "endpoint": "[variables('botEndpoint')]",
         "msaAppId": "[parameters('appId')]",
-        "developerAppInsightsApplicationId": null,
-        "developerAppInsightKey": null,
-        "publishingCredentials": null,
-        "storageResourceId": null
+        "luisAppIds": [],
+        "schemaTransformationVersion": "1.3",
+        "isCmekEnabled": false,
+        "isIsolated": false
       },
       "dependsOn": [
         "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/composer-samples/csharp_dotnetcore/projects/ToDoBotWithLUISSample/ToDoBotWithLUISSample/scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
+++ b/composer-samples/csharp_dotnetcore/projects/ToDoBotWithLUISSample/ToDoBotWithLUISSample/scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
@@ -249,23 +249,24 @@
       "condition": "[parameters('useCosmosDb')]"
     },
     {
-      "apiVersion": "2017-12-01",
+      "apiVersion": "2021-03-01",
       "type": "Microsoft.BotService/botServices",
       "name": "[parameters('botId')]",
       "location": "global",
-      "kind": "bot",
+      "kind": "azurebot",
       "sku": {
         "name": "[parameters('botSku')]"
       },
       "properties": {
         "name": "[parameters('botId')]",
         "displayName": "[parameters('botId')]",
+        "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
         "endpoint": "[variables('botEndpoint')]",
         "msaAppId": "[parameters('appId')]",
-        "developerAppInsightsApplicationId": null,
-        "developerAppInsightKey": null,
-        "publishingCredentials": null,
-        "storageResourceId": null
+        "luisAppIds": [],
+        "schemaTransformationVersion": "1.3",
+        "isCmekEnabled": false,
+        "isIsolated": false
       },
       "dependsOn": [
         "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/composer-samples/csharp_dotnetcore/projects/TodoSample/TodoSample/scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
+++ b/composer-samples/csharp_dotnetcore/projects/TodoSample/TodoSample/scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
@@ -249,23 +249,24 @@
       "condition": "[parameters('useCosmosDb')]"
     },
     {
-      "apiVersion": "2017-12-01",
+      "apiVersion": "2021-03-01",
       "type": "Microsoft.BotService/botServices",
       "name": "[parameters('botId')]",
       "location": "global",
-      "kind": "bot",
+      "kind": "azurebot",
       "sku": {
         "name": "[parameters('botSku')]"
       },
       "properties": {
         "name": "[parameters('botId')]",
         "displayName": "[parameters('botId')]",
+        "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
         "endpoint": "[variables('botEndpoint')]",
         "msaAppId": "[parameters('appId')]",
-        "developerAppInsightsApplicationId": null,
-        "developerAppInsightKey": null,
-        "publishingCredentials": null,
-        "storageResourceId": null
+        "luisAppIds": [],
+        "schemaTransformationVersion": "1.3",
+        "isCmekEnabled": false,
+        "isIsolated": false
       },
       "dependsOn": [
         "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/composer-samples/javascript_nodejs/projects/asking-questions-sample/askingquestionssample/scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
+++ b/composer-samples/javascript_nodejs/projects/asking-questions-sample/askingquestionssample/scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
@@ -249,23 +249,24 @@
       "condition": "[parameters('useCosmosDb')]"
     },
     {
-      "apiVersion": "2017-12-01",
+      "apiVersion": "2021-03-01",
       "type": "Microsoft.BotService/botServices",
       "name": "[parameters('botId')]",
       "location": "global",
-      "kind": "bot",
+      "kind": "azurebot",
       "sku": {
         "name": "[parameters('botSku')]"
       },
       "properties": {
         "name": "[parameters('botId')]",
         "displayName": "[parameters('botId')]",
+        "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
         "endpoint": "[variables('botEndpoint')]",
         "msaAppId": "[parameters('appId')]",
-        "developerAppInsightsApplicationId": null,
-        "developerAppInsightKey": null,
-        "publishingCredentials": null,
-        "storageResourceId": null
+        "luisAppIds": [],
+        "schemaTransformationVersion": "1.3",
+        "isCmekEnabled": false,
+        "isIsolated": false
       },
       "dependsOn": [
         "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/composer-samples/javascript_nodejs/projects/controlling-conversation-flow-sample/controllingconversationflowsample/scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
+++ b/composer-samples/javascript_nodejs/projects/controlling-conversation-flow-sample/controllingconversationflowsample/scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
@@ -249,23 +249,24 @@
       "condition": "[parameters('useCosmosDb')]"
     },
     {
-      "apiVersion": "2017-12-01",
+      "apiVersion": "2021-03-01",
       "type": "Microsoft.BotService/botServices",
       "name": "[parameters('botId')]",
       "location": "global",
-      "kind": "bot",
+      "kind": "azurebot",
       "sku": {
         "name": "[parameters('botSku')]"
       },
       "properties": {
         "name": "[parameters('botId')]",
         "displayName": "[parameters('botId')]",
+        "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
         "endpoint": "[variables('botEndpoint')]",
         "msaAppId": "[parameters('appId')]",
-        "developerAppInsightsApplicationId": null,
-        "developerAppInsightKey": null,
-        "publishingCredentials": null,
-        "storageResourceId": null
+        "luisAppIds": [],
+        "schemaTransformationVersion": "1.3",
+        "isCmekEnabled": false,
+        "isIsolated": false
       },
       "dependsOn": [
         "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/composer-samples/javascript_nodejs/projects/custom-action/customaction/scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
+++ b/composer-samples/javascript_nodejs/projects/custom-action/customaction/scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
@@ -249,23 +249,24 @@
       "condition": "[parameters('useCosmosDb')]"
     },
     {
-      "apiVersion": "2017-12-01",
+      "apiVersion": "2021-03-01",
       "type": "Microsoft.BotService/botServices",
       "name": "[parameters('botId')]",
       "location": "global",
-      "kind": "bot",
+      "kind": "azurebot",
       "sku": {
         "name": "[parameters('botSku')]"
       },
       "properties": {
         "name": "[parameters('botId')]",
         "displayName": "[parameters('botId')]",
+        "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
         "endpoint": "[variables('botEndpoint')]",
         "msaAppId": "[parameters('appId')]",
-        "developerAppInsightsApplicationId": null,
-        "developerAppInsightKey": null,
-        "publishingCredentials": null,
-        "storageResourceId": null
+        "luisAppIds": [],
+        "schemaTransformationVersion": "1.3",
+        "isCmekEnabled": false,
+        "isIsolated": false
       },
       "dependsOn": [
         "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/composer-samples/javascript_nodejs/projects/echo-bot/echobot/scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
+++ b/composer-samples/javascript_nodejs/projects/echo-bot/echobot/scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
@@ -249,23 +249,24 @@
       "condition": "[parameters('useCosmosDb')]"
     },
     {
-      "apiVersion": "2017-12-01",
+      "apiVersion": "2021-03-01",
       "type": "Microsoft.BotService/botServices",
       "name": "[parameters('botId')]",
       "location": "global",
-      "kind": "bot",
+      "kind": "azurebot",
       "sku": {
         "name": "[parameters('botSku')]"
       },
       "properties": {
         "name": "[parameters('botId')]",
         "displayName": "[parameters('botId')]",
+        "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
         "endpoint": "[variables('botEndpoint')]",
         "msaAppId": "[parameters('appId')]",
-        "developerAppInsightsApplicationId": null,
-        "developerAppInsightKey": null,
-        "publishingCredentials": null,
-        "storageResourceId": null
+        "luisAppIds": [],
+        "schemaTransformationVersion": "1.3",
+        "isCmekEnabled": false,
+        "isIsolated": false
       },
       "dependsOn": [
         "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/composer-samples/javascript_nodejs/projects/interruption-sample/interruptionsample/scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
+++ b/composer-samples/javascript_nodejs/projects/interruption-sample/interruptionsample/scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
@@ -249,23 +249,24 @@
       "condition": "[parameters('useCosmosDb')]"
     },
     {
-      "apiVersion": "2017-12-01",
+      "apiVersion": "2021-03-01",
       "type": "Microsoft.BotService/botServices",
       "name": "[parameters('botId')]",
       "location": "global",
-      "kind": "bot",
+      "kind": "azurebot",
       "sku": {
         "name": "[parameters('botSku')]"
       },
       "properties": {
         "name": "[parameters('botId')]",
         "displayName": "[parameters('botId')]",
+        "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
         "endpoint": "[variables('botEndpoint')]",
         "msaAppId": "[parameters('appId')]",
-        "developerAppInsightsApplicationId": null,
-        "developerAppInsightKey": null,
-        "publishingCredentials": null,
-        "storageResourceId": null
+        "luisAppIds": [],
+        "schemaTransformationVersion": "1.3",
+        "isCmekEnabled": false,
+        "isIsolated": false
       },
       "dependsOn": [
         "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/composer-samples/javascript_nodejs/projects/qna-maker-luis-sample/qnamakerluissample/scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
+++ b/composer-samples/javascript_nodejs/projects/qna-maker-luis-sample/qnamakerluissample/scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
@@ -249,23 +249,24 @@
       "condition": "[parameters('useCosmosDb')]"
     },
     {
-      "apiVersion": "2017-12-01",
+      "apiVersion": "2021-03-01",
       "type": "Microsoft.BotService/botServices",
       "name": "[parameters('botId')]",
       "location": "global",
-      "kind": "bot",
+      "kind": "azurebot",
       "sku": {
         "name": "[parameters('botSku')]"
       },
       "properties": {
         "name": "[parameters('botId')]",
         "displayName": "[parameters('botId')]",
+        "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
         "endpoint": "[variables('botEndpoint')]",
         "msaAppId": "[parameters('appId')]",
-        "developerAppInsightsApplicationId": null,
-        "developerAppInsightKey": null,
-        "publishingCredentials": null,
-        "storageResourceId": null
+        "luisAppIds": [],
+        "schemaTransformationVersion": "1.3",
+        "isCmekEnabled": false,
+        "isIsolated": false
       },
       "dependsOn": [
         "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/composer-samples/javascript_nodejs/projects/qna-sample/qnasample/scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
+++ b/composer-samples/javascript_nodejs/projects/qna-sample/qnasample/scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
@@ -249,23 +249,24 @@
       "condition": "[parameters('useCosmosDb')]"
     },
     {
-      "apiVersion": "2017-12-01",
+      "apiVersion": "2021-03-01",
       "type": "Microsoft.BotService/botServices",
       "name": "[parameters('botId')]",
       "location": "global",
-      "kind": "bot",
+      "kind": "azurebot",
       "sku": {
         "name": "[parameters('botSku')]"
       },
       "properties": {
         "name": "[parameters('botId')]",
         "displayName": "[parameters('botId')]",
+        "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
         "endpoint": "[variables('botEndpoint')]",
         "msaAppId": "[parameters('appId')]",
-        "developerAppInsightsApplicationId": null,
-        "developerAppInsightKey": null,
-        "publishingCredentials": null,
-        "storageResourceId": null
+        "luisAppIds": [],
+        "schemaTransformationVersion": "1.3",
+        "isCmekEnabled": false,
+        "isIsolated": false
       },
       "dependsOn": [
         "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/composer-samples/javascript_nodejs/projects/responding-with-cards-sample/respondingwithcardssample/scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
+++ b/composer-samples/javascript_nodejs/projects/responding-with-cards-sample/respondingwithcardssample/scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
@@ -249,23 +249,24 @@
       "condition": "[parameters('useCosmosDb')]"
     },
     {
-      "apiVersion": "2017-12-01",
+      "apiVersion": "2021-03-01",
       "type": "Microsoft.BotService/botServices",
       "name": "[parameters('botId')]",
       "location": "global",
-      "kind": "bot",
+      "kind": "azurebot",
       "sku": {
         "name": "[parameters('botSku')]"
       },
       "properties": {
         "name": "[parameters('botId')]",
         "displayName": "[parameters('botId')]",
+        "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
         "endpoint": "[variables('botEndpoint')]",
         "msaAppId": "[parameters('appId')]",
-        "developerAppInsightsApplicationId": null,
-        "developerAppInsightKey": null,
-        "publishingCredentials": null,
-        "storageResourceId": null
+        "luisAppIds": [],
+        "schemaTransformationVersion": "1.3",
+        "isCmekEnabled": false,
+        "isIsolated": false
       },
       "dependsOn": [
         "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/composer-samples/javascript_nodejs/projects/responding-with-text-sample/respondingwithtextsample/scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
+++ b/composer-samples/javascript_nodejs/projects/responding-with-text-sample/respondingwithtextsample/scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
@@ -249,23 +249,24 @@
       "condition": "[parameters('useCosmosDb')]"
     },
     {
-      "apiVersion": "2017-12-01",
+      "apiVersion": "2021-03-01",
       "type": "Microsoft.BotService/botServices",
       "name": "[parameters('botId')]",
       "location": "global",
-      "kind": "bot",
+      "kind": "azurebot",
       "sku": {
         "name": "[parameters('botSku')]"
       },
       "properties": {
         "name": "[parameters('botId')]",
         "displayName": "[parameters('botId')]",
+        "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
         "endpoint": "[variables('botEndpoint')]",
         "msaAppId": "[parameters('appId')]",
-        "developerAppInsightsApplicationId": null,
-        "developerAppInsightKey": null,
-        "publishingCredentials": null,
-        "storageResourceId": null
+        "luisAppIds": [],
+        "schemaTransformationVersion": "1.3",
+        "isCmekEnabled": false,
+        "isIsolated": false
       },
       "dependsOn": [
         "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/composer-samples/javascript_nodejs/projects/todo-bot-with-luis-sample/todobotwithluissample/scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
+++ b/composer-samples/javascript_nodejs/projects/todo-bot-with-luis-sample/todobotwithluissample/scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
@@ -249,23 +249,24 @@
       "condition": "[parameters('useCosmosDb')]"
     },
     {
-      "apiVersion": "2017-12-01",
+      "apiVersion": "2021-03-01",
       "type": "Microsoft.BotService/botServices",
       "name": "[parameters('botId')]",
       "location": "global",
-      "kind": "bot",
+      "kind": "azurebot",
       "sku": {
         "name": "[parameters('botSku')]"
       },
       "properties": {
         "name": "[parameters('botId')]",
         "displayName": "[parameters('botId')]",
+        "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
         "endpoint": "[variables('botEndpoint')]",
         "msaAppId": "[parameters('appId')]",
-        "developerAppInsightsApplicationId": null,
-        "developerAppInsightKey": null,
-        "publishingCredentials": null,
-        "storageResourceId": null
+        "luisAppIds": [],
+        "schemaTransformationVersion": "1.3",
+        "isCmekEnabled": false,
+        "isIsolated": false
       },
       "dependsOn": [
         "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/composer-samples/javascript_nodejs/projects/todo-sample/todosample/scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
+++ b/composer-samples/javascript_nodejs/projects/todo-sample/todosample/scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
@@ -249,23 +249,24 @@
       "condition": "[parameters('useCosmosDb')]"
     },
     {
-      "apiVersion": "2017-12-01",
+      "apiVersion": "2021-03-01",
       "type": "Microsoft.BotService/botServices",
       "name": "[parameters('botId')]",
       "location": "global",
-      "kind": "bot",
+      "kind": "azurebot",
       "sku": {
         "name": "[parameters('botSku')]"
       },
       "properties": {
         "name": "[parameters('botId')]",
         "displayName": "[parameters('botId')]",
+        "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
         "endpoint": "[variables('botEndpoint')]",
         "msaAppId": "[parameters('appId')]",
-        "developerAppInsightsApplicationId": null,
-        "developerAppInsightKey": null,
-        "publishingCredentials": null,
-        "storageResourceId": null
+        "luisAppIds": [],
+        "schemaTransformationVersion": "1.3",
+        "isCmekEnabled": false,
+        "isIsolated": false
       },
       "dependsOn": [
         "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"


### PR DESCRIPTION
Addresses # 3340

## Proposed Changes
This PR updates the deployment templates (`function-template-with-preexisting-rg.json`) of the bots inside [composer-samples](https://github.com/microsoft/BotBuilder-Samples/tree/main/composer-samples) folder to use the new Azure resource `Azure Bot` instead of the Bot Channel Registration.

> **Note:** The bots in the the list are Azure Web Apps instead of Azure Functions, therefore the bot won't work using this template, to validate that the template is working, we created an Azure Functions Empty bot.

### Detailed Changes
Updated the ARM templates of the following samples:

**csharp_dotnetcore**
- csharp_dotnetcore/projects/AskingQuestionsSample/AskingQuestionsSample
- csharp_dotnetcore/projects/ControllingConversationFlowSample/ControllingConversationFlowSample
- csharp_dotnetcore/projects/CustomAction/CustomAction
- csharp_dotnetcore/projects/CustomTrigger/CustomTrigger
- csharp_dotnetcore/projects/EchoBot/EchoBot
- csharp_dotnetcore/projects/InterruptionSample/InterruptionSample
- csharp_dotnetcore/projects/OrchestratorDispatch
- csharp_dotnetcore/projects/OrchestratorSchoolNavigator/SchoolNavigator
- csharp_dotnetcore/projects/QnAMakerLUISSample/QnAMakerLUISSample
- csharp_dotnetcore/projects/QnASample/QnASample
- csharp_dotnetcore/projects/RespondingWithCardsSample/RespondingWithCardsSample
- csharp_dotnetcore/projects/RespondingWithTextSample/RespondingWithTextSample
- csharp_dotnetcore/projects/ToDoBotWithLUISSample/ToDoBotWithLUISSample
- csharp_dotnetcore/projects/TodoSample/TodoSample

**javascript_nodejs**
- javascript_nodejs/projects/asking-questions-sample/askingquestionssample
- javascript_nodejs/projects/controlling-conversation-flow-sample/controllingconversationflowsample
- javascript_nodejs/projects/custom-action/customaction
- javascript_nodejs/projects/echo-bot/echobot
- javascript_nodejs/projects/interruption-sample/interruptionsample
- javascript_nodejs/projects/qna-maker-luis-sample/qnamakerluissample
- javascript_nodejs/projects/qna-sample/qnasample
- javascript_nodejs/projects/responding-with-cards-sample/respondingwithcardssample
- javascript_nodejs/projects/responding-with-text-sample/respondingwithtextsample
- javascript_nodejs/projects/todo-bot-with-luis-sample/todobotwithluissample
- javascript_nodejs/projects/todo-sample/todosample

## Testing
The following image shows an empty bot working in a function app with the new Azure Bot resource.
![image](https://user-images.githubusercontent.com/62260472/130853007-16558e86-1353-4c83-ba6f-ce22f87eebf6.png)
