### PR TITLE
[#3340] Deployment ARM templates update (template-with-preexisting-rg) - Generators folder

### DIFF
--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.CoreBot/content/CoreBot/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.CoreBot/content/CoreBot/DeploymentTemplates/template-with-preexisting-rg.json
@@ -129,23 +129,24 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EchoBot/content/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EchoBot/content/DeploymentTemplates/template-with-preexisting-rg.json
@@ -129,23 +129,24 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EmptyBot/content/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EmptyBot/content/DeploymentTemplates/template-with-preexisting-rg.json
@@ -129,23 +129,24 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/generators/generator-botbuilder/generators/app/templates/core/deploymentTemplates/template-with-preexisting-rg.json
+++ b/generators/generator-botbuilder/generators/app/templates/core/deploymentTemplates/template-with-preexisting-rg.json
@@ -128,23 +128,24 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/generators/generator-botbuilder/generators/app/templates/echo/deploymentTemplates/template-with-preexisting-rg.json
+++ b/generators/generator-botbuilder/generators/app/templates/echo/deploymentTemplates/template-with-preexisting-rg.json
@@ -128,23 +128,24 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/generators/generator-botbuilder/generators/app/templates/empty/deploymentTemplates/template-with-preexisting-rg.json
+++ b/generators/generator-botbuilder/generators/app/templates/empty/deploymentTemplates/template-with-preexisting-rg.json
@@ -128,23 +128,24 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/generators/java/generators/app/templates/core/project/deploymentTemplates/template-with-preexisting-rg.json
+++ b/generators/java/generators/app/templates/core/project/deploymentTemplates/template-with-preexisting-rg.json
@@ -233,23 +233,24 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/generators/java/generators/app/templates/echo/project/deploymentTemplates/template-with-preexisting-rg.json
+++ b/generators/java/generators/app/templates/echo/project/deploymentTemplates/template-with-preexisting-rg.json
@@ -233,23 +233,24 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/generators/java/generators/app/templates/empty/project/deploymentTemplates/template-with-preexisting-rg.json
+++ b/generators/java/generators/app/templates/empty/project/deploymentTemplates/template-with-preexisting-rg.json
@@ -233,23 +233,24 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/generators/python/app/templates/core/{{cookiecutter.bot_name}}/deploymentTemplates/template-with-preexisting-rg.json
+++ b/generators/python/app/templates/core/{{cookiecutter.bot_name}}/deploymentTemplates/template-with-preexisting-rg.json
@@ -216,23 +216,24 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/generators/python/app/templates/echo/{{cookiecutter.bot_name}}/deploymentTemplates/template-with-preexisting-rg.json
+++ b/generators/python/app/templates/echo/{{cookiecutter.bot_name}}/deploymentTemplates/template-with-preexisting-rg.json
@@ -216,23 +216,24 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/generators/python/app/templates/empty/{{cookiecutter.bot_name}}/deploymentTemplates/template-with-preexisting-rg.json
+++ b/generators/python/app/templates/empty/{{cookiecutter.bot_name}}/deploymentTemplates/template-with-preexisting-rg.json
@@ -216,23 +216,24 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBot-Core21/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBot-Core21/DeploymentTemplates/template-with-preexisting-rg.json
@@ -129,23 +129,24 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBot/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBot/DeploymentTemplates/template-with-preexisting-rg.json
@@ -129,23 +129,24 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBotWithTests-Core21/CoreBot/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBotWithTests-Core21/CoreBot/DeploymentTemplates/template-with-preexisting-rg.json
@@ -129,23 +129,24 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBotWithTests/CoreBot/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBotWithTests/CoreBot/DeploymentTemplates/template-with-preexisting-rg.json
@@ -129,23 +129,24 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EchoBot-Core21/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EchoBot-Core21/DeploymentTemplates/template-with-preexisting-rg.json
@@ -129,23 +129,24 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EchoBot/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EchoBot/DeploymentTemplates/template-with-preexisting-rg.json
@@ -129,23 +129,24 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EmptyBot-Core21/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EmptyBot-Core21/DeploymentTemplates/template-with-preexisting-rg.json
@@ -129,23 +129,24 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EmptyBot/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EmptyBot/DeploymentTemplates/template-with-preexisting-rg.json
@@ -129,23 +129,24 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"


### PR DESCRIPTION
Addresses # 3340

## Proposed Changes
This PR updates the deployment templates (`template-with-preexisting-rg`) of the bots inside [generators](https://github.com/microsoft/BotBuilder-Samples/tree/main/generators) folder to use the new Azure resource `Azure Bot` instead of the Bot Channel Registration.

### Detailed Changes
Updated the ARM templates of the following projects:
- dotnet-templates
   - CoreBot
   - EchoBot
   - EmptyBot
- generator-botbuilder
   - core
   - echo
   - empty
- java/generators
   - core
   - echo
   - empty
- python
   - core
   - echo
   - empty
- vsix-vs-win/BotBuilderVSIX-V4
   - CoreBot-Core21
   - CoreBot
   - CoreBotWithTests-Core21
   - CoreBotWithTests
   - EchoBot-Core21
   - EchoBot
   - EmptyBot-Core21
   - EmptyBot

## Testing
These images show some of the javascript_nodejs samples deployed in Azure and working as expected.
![image](https://user-images.githubusercontent.com/44245136/130855013-e88f985a-5e3b-4cd0-9e01-fb364d23e6a5.png)