### PR TITLE
[#3526] Add support for MSI to JS samples and generators - generators

### DIFF
--- a/generators/generator-botbuilder/generators/app/templates/core/_env
+++ b/generators/generator-botbuilder/generators/app/templates/core/_env
@@ -1,5 +1,7 @@
+MicrosoftAppType=
 MicrosoftAppId=
 MicrosoftAppPassword=
+MicrosoftAppTenantId=
 LuisAppId=
 LuisAPIKey=
 LuisAPIHostName=

--- a/generators/generator-botbuilder/generators/app/templates/core/index.js
+++ b/generators/generator-botbuilder/generators/app/templates/core/index.js
@@ -36,7 +36,9 @@ const BOOKING_DIALOG = 'bookingDialog';
 
 const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
     MicrosoftAppId: process.env.MicrosoftAppId,
-    MicrosoftAppPassword: process.env.MicrosoftAppPassword
+    MicrosoftAppPassword: process.env.MicrosoftAppPassword,
+    MicrosoftAppType: process.env.MicrosoftAppType,
+    MicrosoftAppTenantId: process.env.MicrosoftAppTenantId
 });
 
 const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory);

--- a/generators/generator-botbuilder/generators/app/templates/core/index.ts
+++ b/generators/generator-botbuilder/generators/app/templates/core/index.ts
@@ -37,7 +37,9 @@ import { FlightBookingRecognizer } from './dialogs/flightBookingRecognizer';
 
 const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
     MicrosoftAppId: process.env.MicrosoftAppId,
-    MicrosoftAppPassword: process.env.MicrosoftAppPassword
+    MicrosoftAppPassword: process.env.MicrosoftAppPassword,
+    MicrosoftAppType: process.env.MicrosoftAppType,
+    MicrosoftAppTenantId: process.env.MicrosoftAppTenantId
 });
 
 const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory);

--- a/generators/generator-botbuilder/generators/app/templates/core/package-with-tests.json.js
+++ b/generators/generator-botbuilder/generators/app/templates/core/package-with-tests.json.js
@@ -17,10 +17,10 @@
     },
     "dependencies": {
         "@microsoft/recognizers-text-data-types-timex-expression": "1.1.4",
-        "botbuilder": "~4.14.0",
-        "botbuilder-ai": "~4.14.0",
-        "botbuilder-dialogs": "~4.14.0",
-        "botbuilder-testing": "~4.14.0",
+        "botbuilder": "~4.15.0-rc0",
+        "botbuilder-ai": "~4.15.0-rc0",
+        "botbuilder-dialogs": "~4.15.0-rc0",
+        "botbuilder-testing": "~4.15.0-rc0",
         "dotenv": "^8.2.0",
         "restify": "^8.5.1"
     },

--- a/generators/generator-botbuilder/generators/app/templates/core/package-with-tests.json.ts
+++ b/generators/generator-botbuilder/generators/app/templates/core/package-with-tests.json.ts
@@ -38,10 +38,10 @@
     },
     "dependencies": {
       "@microsoft/recognizers-text-data-types-timex-expression": "1.1.4",
-      "botbuilder": "~4.14.0",
-      "botbuilder-ai": "~4.14.0",
-      "botbuilder-dialogs": "~4.14.0",
-      "botbuilder-testing": "~4.14.0",
+      "botbuilder": "~4.15.0-rc0",
+      "botbuilder-ai": "~4.15.0-rc0",
+      "botbuilder-dialogs": "~4.15.0-rc0",
+      "botbuilder-testing": "~4.15.0-rc0",
       "dotenv": "^8.2.0",
       "replace": "~1.2.0",
       "restify": "~8.5.1"

--- a/generators/generator-botbuilder/generators/app/templates/core/package.json.js
+++ b/generators/generator-botbuilder/generators/app/templates/core/package.json.js
@@ -17,9 +17,9 @@
     },
     "dependencies": {
         "@microsoft/recognizers-text-data-types-timex-expression": "1.1.4",
-        "botbuilder": "~4.14.0",
-        "botbuilder-ai": "~4.14.0",
-        "botbuilder-dialogs": "~4.14.0",
+        "botbuilder": "~~4.15.0-rc0",
+        "botbuilder-ai": "~~4.15.0-rc0",
+        "botbuilder-dialogs": "~~4.15.0-rc0",
         "dotenv": "~8.2.0",
         "restify": "~8.5.1"
     },

--- a/generators/generator-botbuilder/generators/app/templates/core/package.json.js
+++ b/generators/generator-botbuilder/generators/app/templates/core/package.json.js
@@ -17,9 +17,9 @@
     },
     "dependencies": {
         "@microsoft/recognizers-text-data-types-timex-expression": "1.1.4",
-        "botbuilder": "~~4.15.0-rc0",
-        "botbuilder-ai": "~~4.15.0-rc0",
-        "botbuilder-dialogs": "~~4.15.0-rc0",
+        "botbuilder": "~4.15.0-rc0",
+        "botbuilder-ai": "~4.15.0-rc0",
+        "botbuilder-dialogs": "~4.15.0-rc0",
         "dotenv": "~8.2.0",
         "restify": "~8.5.1"
     },

--- a/generators/generator-botbuilder/generators/app/templates/core/package.json.ts
+++ b/generators/generator-botbuilder/generators/app/templates/core/package.json.ts
@@ -19,9 +19,9 @@
     },
     "dependencies": {
         "@microsoft/recognizers-text-data-types-timex-expression": "1.1.4",
-        "botbuilder": "~4.14.0",
-        "botbuilder-ai": "~4.14.0",
-        "botbuilder-dialogs": "~4.14.0",
+        "botbuilder": "~4.15.0-rc0",
+        "botbuilder-ai": "~4.15.0-rc0",
+        "botbuilder-dialogs": "~4.15.0-rc0",
         "dotenv": "~8.2.0",
         "replace": "~1.2.0",
         "restify": "~8.5.1"

--- a/generators/generator-botbuilder/generators/app/templates/echo/_env
+++ b/generators/generator-botbuilder/generators/app/templates/echo/_env
@@ -1,2 +1,4 @@
+MicrosoftAppType=
 MicrosoftAppId=
 MicrosoftAppPassword=
+MicrosoftAppTenantId=

--- a/generators/generator-botbuilder/generators/app/templates/echo/index.js
+++ b/generators/generator-botbuilder/generators/app/templates/echo/index.js
@@ -33,7 +33,9 @@ server.listen(process.env.port || process.env.PORT || 3978, () => {
 
 const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
     MicrosoftAppId: process.env.MicrosoftAppId,
-    MicrosoftAppPassword: process.env.MicrosoftAppPassword
+    MicrosoftAppPassword: process.env.MicrosoftAppPassword,
+    MicrosoftAppType: process.env.MicrosoftAppType,
+    MicrosoftAppTenantId: process.env.MicrosoftAppTenantId
 });
 
 const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory);

--- a/generators/generator-botbuilder/generators/app/templates/echo/index.ts
+++ b/generators/generator-botbuilder/generators/app/templates/echo/index.ts
@@ -35,7 +35,9 @@ server.listen(process.env.port || process.env.PORT || 3978, () => {
 
 const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
     MicrosoftAppId: process.env.MicrosoftAppId,
-    MicrosoftAppPassword: process.env.MicrosoftAppPassword
+    MicrosoftAppPassword: process.env.MicrosoftAppPassword,
+    MicrosoftAppType: process.env.MicrosoftAppType,
+    MicrosoftAppTenantId: process.env.MicrosoftAppTenantId
 });
 
 const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory);

--- a/generators/generator-botbuilder/generators/app/templates/echo/package.json.js
+++ b/generators/generator-botbuilder/generators/app/templates/echo/package.json.js
@@ -16,7 +16,7 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "botbuilder": "~4.14.0",
+        "botbuilder": "~4.15.0-rc0",
         "dotenv": "~8.2.0",
         "restify": "~8.5.1"
     },

--- a/generators/generator-botbuilder/generators/app/templates/echo/package.json.ts
+++ b/generators/generator-botbuilder/generators/app/templates/echo/package.json.ts
@@ -18,7 +18,7 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "botbuilder": "~4.14.0",
+        "botbuilder": "~4.15.0-rc0",
         "dotenv": "~8.2.0",
         "replace": "~1.2.0",
         "restify": "~8.5.1"

--- a/generators/generator-botbuilder/generators/app/templates/empty/_env
+++ b/generators/generator-botbuilder/generators/app/templates/empty/_env
@@ -1,2 +1,4 @@
+MicrosoftAppType=
 MicrosoftAppId=
 MicrosoftAppPassword=
+MicrosoftAppTenantId=

--- a/generators/generator-botbuilder/generators/app/templates/empty/index.js
+++ b/generators/generator-botbuilder/generators/app/templates/empty/index.js
@@ -24,7 +24,9 @@ server.listen(process.env.port || process.env.PORT || 3978, () => {
 
 const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
     MicrosoftAppId: process.env.MicrosoftAppId,
-    MicrosoftAppPassword: process.env.MicrosoftAppPassword
+    MicrosoftAppPassword: process.env.MicrosoftAppPassword,
+    MicrosoftAppType: process.env.MicrosoftAppType,
+    MicrosoftAppTenantId: process.env.MicrosoftAppTenantId
 });
 
 const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory);

--- a/generators/generator-botbuilder/generators/app/templates/empty/index.ts
+++ b/generators/generator-botbuilder/generators/app/templates/empty/index.ts
@@ -24,7 +24,9 @@ server.listen(process.env.port || process.env.PORT || 3978, () => {
 
 const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
     MicrosoftAppId: process.env.MicrosoftAppId,
-    MicrosoftAppPassword: process.env.MicrosoftAppPassword
+    MicrosoftAppPassword: process.env.MicrosoftAppPassword,
+    MicrosoftAppType: process.env.MicrosoftAppType,
+    MicrosoftAppTenantId: process.env.MicrosoftAppTenantId
 });
 
 const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory);

--- a/generators/generator-botbuilder/generators/app/templates/empty/package.json.js
+++ b/generators/generator-botbuilder/generators/app/templates/empty/package.json.js
@@ -16,7 +16,7 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "botbuilder": "~4.14.0",
+        "botbuilder": "~4.15.0-rc0",
         "restify": "~8.5.1"
     },
     "devDependencies": {

--- a/generators/generator-botbuilder/generators/app/templates/empty/package.json.ts
+++ b/generators/generator-botbuilder/generators/app/templates/empty/package.json.ts
@@ -18,7 +18,7 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "botbuilder": "~4.14.0",
+        "botbuilder": "~4.15.0-rc0",
         "replace": "~1.2.0",
         "restify": "~8.5.1"
     },


### PR DESCRIPTION
Addresses # 3526

## Description
This PR updates the generators' template bots adding support for MSI and SingleTenant App types.
It includes both, JavaScript and Typescript templates.

### Detailed Changes
- Updated the **_botbuilder_** dependency to the RC0 version.
- Updated **_index.js_** to pass the new parameters AppType and AppTenantId to the _ConfigurationServiceClientCredentialFactory_ instance.
- Added the new settings _MicrosoftAppType_ and _MicrosoftAppTenantId_ to the **_env_** file.
- Added missing .env file for sample _13.core-bot_.

This PR updates the following samples:
- JavaScript
   - Core
   - Echo
   - Empty
- TypeScript
   - Core
   - Echo
   - Empty

## Testing
The following images show the three bots working with the three different app types: MultiTenant, SingleTenant, and MSI.
![image](https://user-images.githubusercontent.com/44245136/138501339-9eac35ee-560d-408f-9ab2-b1eaa0375073.png)
