### PR TITLE
[#3526] Add support for MSI to JS samples and generators - QnA samples

### DIFF
--- a/samples/javascript_nodejs/11.qnamaker/.env
+++ b/samples/javascript_nodejs/11.qnamaker/.env
@@ -6,4 +6,3 @@ MicrosoftAppTenantId=
 QnAKnowledgebaseId=
 QnAEndpointKey=
 QnAEndpointHostName=
-DefaultAnswer=

--- a/samples/javascript_nodejs/11.qnamaker/.env
+++ b/samples/javascript_nodejs/11.qnamaker/.env
@@ -1,5 +1,9 @@
+MicrosoftAppType=
 MicrosoftAppId=
 MicrosoftAppPassword=
+MicrosoftAppTenantId=
+
 QnAKnowledgebaseId=
 QnAEndpointKey=
 QnAEndpointHostName=
+DefaultAnswer=

--- a/samples/javascript_nodejs/11.qnamaker/index.js
+++ b/samples/javascript_nodejs/11.qnamaker/index.js
@@ -25,9 +25,9 @@ const {
 const { QnABot } = require('./bots/QnABot');
 
 const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
-    MicrosoftAppType: process.env.MicrosoftAppType,
     MicrosoftAppId: process.env.MicrosoftAppId,
     MicrosoftAppPassword: process.env.MicrosoftAppPassword,
+    MicrosoftAppType: process.env.MicrosoftAppType,
     MicrosoftAppTenantId: process.env.MicrosoftAppTenantId
 });
 

--- a/samples/javascript_nodejs/11.qnamaker/index.js
+++ b/samples/javascript_nodejs/11.qnamaker/index.js
@@ -25,8 +25,10 @@ const {
 const { QnABot } = require('./bots/QnABot');
 
 const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
+    MicrosoftAppType: process.env.MicrosoftAppType,
     MicrosoftAppId: process.env.MicrosoftAppId,
-    MicrosoftAppPassword: process.env.MicrosoftAppPassword
+    MicrosoftAppPassword: process.env.MicrosoftAppPassword,
+    MicrosoftAppTenantId: process.env.MicrosoftAppTenantId
 });
 
 const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory);

--- a/samples/javascript_nodejs/11.qnamaker/package.json
+++ b/samples/javascript_nodejs/11.qnamaker/package.json
@@ -16,8 +16,8 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.14.0",
-        "botbuilder-ai": "~4.14.0",
+        "botbuilder": "~4.15.0-rc0",
+        "botbuilder-ai": "~4.15.0-rc0",
         "dotenv": "^8.2.0",
         "restify": "~8.5.1"
     },

--- a/samples/javascript_nodejs/49.qnamaker-all-features/.env
+++ b/samples/javascript_nodejs/49.qnamaker-all-features/.env
@@ -1,5 +1,7 @@
+MicrosoftAppType=
 MicrosoftAppId=
 MicrosoftAppPassword=
+MicrosoftAppTenantId=
 
 QnAKnowledgebaseId=
 QnAEndpointKey=

--- a/samples/javascript_nodejs/49.qnamaker-all-features/index.js
+++ b/samples/javascript_nodejs/49.qnamaker-all-features/index.js
@@ -28,7 +28,9 @@ const { RootDialog } = require('./dialogs/rootDialog');
 
 const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
     MicrosoftAppId: process.env.MicrosoftAppId,
-    MicrosoftAppPassword: process.env.MicrosoftAppPassword
+    MicrosoftAppPassword: process.env.MicrosoftAppPassword,
+    MicrosoftAppType: process.env.MicrosoftAppType,
+    MicrosoftAppTenantId: process.env.MicrosoftAppTenantId
 });
 
 const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory);

--- a/samples/javascript_nodejs/49.qnamaker-all-features/package.json
+++ b/samples/javascript_nodejs/49.qnamaker-all-features/package.json
@@ -16,9 +16,9 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.14.0",
-        "botbuilder-ai": "~4.14.0",
-        "botbuilder-dialogs": "~4.14.0",
+        "botbuilder": "~4.15.0-rc0",
+        "botbuilder-ai": "~4.15.0-rc0",
+        "botbuilder-dialogs": "~4.15.0-rc0",
         "dotenv": "^8.2.0",
         "restify": "~8.5.1"
     },


### PR DESCRIPTION
Addresses # 3526

## Description
This PR updates the QnA sample bots adding support for MSI and SingleTenant App types.

### Detailed Changes
- Updated the **_botbuilder_** dependency to the RC0 version.
- Updated **_index.js_** to pass the new parameters AppType and AppTenantId to the 
- Added the new settings _MicrosoftAppType_ and _MicrosoftAppTenantId_ to the **_env_** file.

This PR updates the following samples:
- JavaScript
   - 11.qnamaker
   - 49.qnamaker-all-features.

## Testing
The following images show one of the bots working with User Assigned MSI configuration.
![image](https://user-images.githubusercontent.com/18757147/138517116-dd1b363d-f009-4afc-a03e-382122bff9fa.png)

