### PR TITLE
[#3536] Add support for MSI to JS samples and generators - ARM preexisting RG parameters (1/2)

### DIFF
--- a/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/preexisting-rg-parameters.json
+++ b/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/preexisting-rg-parameters.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "appId": {
@@ -7,6 +7,9 @@
         },
         "appSecret": {
             "value": ""
+        },
+        "appType": {
+            "value": "MultiTenant"
         },
         "botId": {
             "value": ""
@@ -33,6 +36,15 @@
             "value": ""
         },
         "newWebAppName": {
+            "value": ""
+        },
+        "tenantId": {
+            "value": ""
+        },
+        "existingUserAssignedMSIName": {
+            "value": ""
+        },
+        "existingUserAssignedMSIResourceGroupName": {
             "value": ""
         }
     }

--- a/samples/javascript_nodejs/03.welcome-users/deploymentTemplates/preexisting-rg-parameters.json
+++ b/samples/javascript_nodejs/03.welcome-users/deploymentTemplates/preexisting-rg-parameters.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "appId": {
@@ -7,6 +7,9 @@
         },
         "appSecret": {
             "value": ""
+        },
+        "appType": {
+            "value": "MultiTenant"
         },
         "botId": {
             "value": ""
@@ -33,6 +36,15 @@
             "value": ""
         },
         "newWebAppName": {
+            "value": ""
+        },
+        "tenantId": {
+            "value": ""
+        },
+        "existingUserAssignedMSIName": {
+            "value": ""
+        },
+        "existingUserAssignedMSIResourceGroupName": {
             "value": ""
         }
     }

--- a/samples/javascript_nodejs/05.multi-turn-prompt/deploymentTemplates/preexisting-rg-parameters.json
+++ b/samples/javascript_nodejs/05.multi-turn-prompt/deploymentTemplates/preexisting-rg-parameters.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "appId": {
@@ -7,6 +7,9 @@
         },
         "appSecret": {
             "value": ""
+        },
+        "appType": {
+            "value": "MultiTenant"
         },
         "botId": {
             "value": ""
@@ -33,6 +36,15 @@
             "value": ""
         },
         "newWebAppName": {
+            "value": ""
+        },
+        "tenantId": {
+            "value": ""
+        },
+        "existingUserAssignedMSIName": {
+            "value": ""
+        },
+        "existingUserAssignedMSIResourceGroupName": {
             "value": ""
         }
     }

--- a/samples/javascript_nodejs/06.using-cards/deploymentTemplates/preexisting-rg-parameters.json
+++ b/samples/javascript_nodejs/06.using-cards/deploymentTemplates/preexisting-rg-parameters.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "appId": {
@@ -7,6 +7,9 @@
         },
         "appSecret": {
             "value": ""
+        },
+        "appType": {
+            "value": "MultiTenant"
         },
         "botId": {
             "value": ""
@@ -33,6 +36,15 @@
             "value": ""
         },
         "newWebAppName": {
+            "value": ""
+        },
+        "tenantId": {
+            "value": ""
+        },
+        "existingUserAssignedMSIName": {
+            "value": ""
+        },
+        "existingUserAssignedMSIResourceGroupName": {
             "value": ""
         }
     }

--- a/samples/javascript_nodejs/07.using-adaptive-cards/deploymentTemplates/preexisting-rg-parameters.json
+++ b/samples/javascript_nodejs/07.using-adaptive-cards/deploymentTemplates/preexisting-rg-parameters.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "appId": {
@@ -7,6 +7,9 @@
         },
         "appSecret": {
             "value": ""
+        },
+        "appType": {
+            "value": "MultiTenant"
         },
         "botId": {
             "value": ""
@@ -33,6 +36,15 @@
             "value": ""
         },
         "newWebAppName": {
+            "value": ""
+        },
+        "tenantId": {
+            "value": ""
+        },
+        "existingUserAssignedMSIName": {
+            "value": ""
+        },
+        "existingUserAssignedMSIResourceGroupName": {
             "value": ""
         }
     }

--- a/samples/javascript_nodejs/08.suggested-actions/deploymentTemplates/preexisting-rg-parameters.json
+++ b/samples/javascript_nodejs/08.suggested-actions/deploymentTemplates/preexisting-rg-parameters.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "appId": {
@@ -7,6 +7,9 @@
         },
         "appSecret": {
             "value": ""
+        },
+        "appType": {
+            "value": "MultiTenant"
         },
         "botId": {
             "value": ""
@@ -33,6 +36,15 @@
             "value": ""
         },
         "newWebAppName": {
+            "value": ""
+        },
+        "tenantId": {
+            "value": ""
+        },
+        "existingUserAssignedMSIName": {
+            "value": ""
+        },
+        "existingUserAssignedMSIResourceGroupName": {
             "value": ""
         }
     }

--- a/samples/javascript_nodejs/11.qnamaker/deploymentTemplates/preexisting-rg-parameters.json
+++ b/samples/javascript_nodejs/11.qnamaker/deploymentTemplates/preexisting-rg-parameters.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "appId": {
@@ -7,6 +7,9 @@
         },
         "appSecret": {
             "value": ""
+        },
+        "appType": {
+            "value": "MultiTenant"
         },
         "botId": {
             "value": ""
@@ -33,6 +36,15 @@
             "value": ""
         },
         "newWebAppName": {
+            "value": ""
+        },
+        "tenantId": {
+            "value": ""
+        },
+        "existingUserAssignedMSIName": {
+            "value": ""
+        },
+        "existingUserAssignedMSIResourceGroupName": {
             "value": ""
         }
     }

--- a/samples/javascript_nodejs/13.core-bot/deploymentTemplates/preexisting-rg-parameters.json
+++ b/samples/javascript_nodejs/13.core-bot/deploymentTemplates/preexisting-rg-parameters.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "appId": {
@@ -7,6 +7,9 @@
         },
         "appSecret": {
             "value": ""
+        },
+        "appType": {
+            "value": "MultiTenant"
         },
         "botId": {
             "value": ""
@@ -33,6 +36,15 @@
             "value": ""
         },
         "newWebAppName": {
+            "value": ""
+        },
+        "tenantId": {
+            "value": ""
+        },
+        "existingUserAssignedMSIName": {
+            "value": ""
+        },
+        "existingUserAssignedMSIResourceGroupName": {
             "value": ""
         }
     }

--- a/samples/javascript_nodejs/14.nlp-with-orchestrator/deploymentTemplates/preexisting-rg-parameters.json
+++ b/samples/javascript_nodejs/14.nlp-with-orchestrator/deploymentTemplates/preexisting-rg-parameters.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "appId": {
@@ -7,6 +7,9 @@
         },
         "appSecret": {
             "value": ""
+        },
+        "appType": {
+            "value": "MultiTenant"
         },
         "botId": {
             "value": ""
@@ -33,6 +36,15 @@
             "value": ""
         },
         "newWebAppName": {
+            "value": ""
+        },
+        "tenantId": {
+            "value": ""
+        },
+        "existingUserAssignedMSIName": {
+            "value": ""
+        },
+        "existingUserAssignedMSIResourceGroupName": {
             "value": ""
         }
     }

--- a/samples/javascript_nodejs/15.handling-attachments/deploymentTemplates/preexisting-rg-parameters.json
+++ b/samples/javascript_nodejs/15.handling-attachments/deploymentTemplates/preexisting-rg-parameters.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "appId": {
@@ -7,6 +7,9 @@
         },
         "appSecret": {
             "value": ""
+        },
+        "appType": {
+            "value": "MultiTenant"
         },
         "botId": {
             "value": ""
@@ -33,6 +36,15 @@
             "value": ""
         },
         "newWebAppName": {
+            "value": ""
+        },
+        "tenantId": {
+            "value": ""
+        },
+        "existingUserAssignedMSIName": {
+            "value": ""
+        },
+        "existingUserAssignedMSIResourceGroupName": {
             "value": ""
         }
     }

--- a/samples/javascript_nodejs/16.proactive-messages/deploymentTemplates/preexisting-rg-parameters.json
+++ b/samples/javascript_nodejs/16.proactive-messages/deploymentTemplates/preexisting-rg-parameters.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "appId": {
@@ -7,6 +7,9 @@
         },
         "appSecret": {
             "value": ""
+        },
+        "appType": {
+            "value": "MultiTenant"
         },
         "botId": {
             "value": ""
@@ -33,6 +36,15 @@
             "value": ""
         },
         "newWebAppName": {
+            "value": ""
+        },
+        "tenantId": {
+            "value": ""
+        },
+        "existingUserAssignedMSIName": {
+            "value": ""
+        },
+        "existingUserAssignedMSIResourceGroupName": {
             "value": ""
         }
     }

--- a/samples/javascript_nodejs/17.multilingual-bot/deploymentTemplates/preexisting-rg-parameters.json
+++ b/samples/javascript_nodejs/17.multilingual-bot/deploymentTemplates/preexisting-rg-parameters.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "appId": {
@@ -7,6 +7,9 @@
         },
         "appSecret": {
             "value": ""
+        },
+        "appType": {
+            "value": "MultiTenant"
         },
         "botId": {
             "value": ""
@@ -33,6 +36,15 @@
             "value": ""
         },
         "newWebAppName": {
+            "value": ""
+        },
+        "tenantId": {
+            "value": ""
+        },
+        "existingUserAssignedMSIName": {
+            "value": ""
+        },
+        "existingUserAssignedMSIResourceGroupName": {
             "value": ""
         }
     }

--- a/samples/javascript_nodejs/18.bot-authentication/deploymentTemplates/preexisting-rg-parameters.json
+++ b/samples/javascript_nodejs/18.bot-authentication/deploymentTemplates/preexisting-rg-parameters.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "appId": {
@@ -7,6 +7,9 @@
         },
         "appSecret": {
             "value": ""
+        },
+        "appType": {
+            "value": "MultiTenant"
         },
         "botId": {
             "value": ""
@@ -33,6 +36,15 @@
             "value": ""
         },
         "newWebAppName": {
+            "value": ""
+        },
+        "tenantId": {
+            "value": ""
+        },
+        "existingUserAssignedMSIName": {
+            "value": ""
+        },
+        "existingUserAssignedMSIResourceGroupName": {
             "value": ""
         }
     }

--- a/samples/javascript_nodejs/19.custom-dialogs/deploymentTemplates/preexisting-rg-parameters.json
+++ b/samples/javascript_nodejs/19.custom-dialogs/deploymentTemplates/preexisting-rg-parameters.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "appId": {
@@ -7,6 +7,9 @@
         },
         "appSecret": {
             "value": ""
+        },
+        "appType": {
+            "value": "MultiTenant"
         },
         "botId": {
             "value": ""
@@ -33,6 +36,15 @@
             "value": ""
         },
         "newWebAppName": {
+            "value": ""
+        },
+        "tenantId": {
+            "value": ""
+        },
+        "existingUserAssignedMSIName": {
+            "value": ""
+        },
+        "existingUserAssignedMSIResourceGroupName": {
             "value": ""
         }
     }

--- a/samples/javascript_nodejs/21.corebot-app-insights/deploymentTemplates/preexisting-rg-parameters.json
+++ b/samples/javascript_nodejs/21.corebot-app-insights/deploymentTemplates/preexisting-rg-parameters.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "appId": {
@@ -7,6 +7,9 @@
         },
         "appSecret": {
             "value": ""
+        },
+        "appType": {
+            "value": "MultiTenant"
         },
         "botId": {
             "value": ""
@@ -33,6 +36,15 @@
             "value": ""
         },
         "newWebAppName": {
+            "value": ""
+        },
+        "tenantId": {
+            "value": ""
+        },
+        "existingUserAssignedMSIName": {
+            "value": ""
+        },
+        "existingUserAssignedMSIResourceGroupName": {
             "value": ""
         }
     }

--- a/samples/javascript_nodejs/23.facebook-events/deploymentTemplates/preexisting-rg-parameters.json
+++ b/samples/javascript_nodejs/23.facebook-events/deploymentTemplates/preexisting-rg-parameters.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "appId": {
@@ -7,6 +7,9 @@
         },
         "appSecret": {
             "value": ""
+        },
+        "appType": {
+            "value": "MultiTenant"
         },
         "botId": {
             "value": ""
@@ -33,6 +36,15 @@
             "value": ""
         },
         "newWebAppName": {
+            "value": ""
+        },
+        "tenantId": {
+            "value": ""
+        },
+        "existingUserAssignedMSIName": {
+            "value": ""
+        },
+        "existingUserAssignedMSIResourceGroupName": {
             "value": ""
         }
     }

--- a/samples/javascript_nodejs/24.bot-authentication-msgraph/deploymentTemplates/preexisting-rg-parameters.json
+++ b/samples/javascript_nodejs/24.bot-authentication-msgraph/deploymentTemplates/preexisting-rg-parameters.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "appId": {
@@ -7,6 +7,9 @@
         },
         "appSecret": {
             "value": ""
+        },
+        "appType": {
+            "value": "MultiTenant"
         },
         "botId": {
             "value": ""
@@ -33,6 +36,15 @@
             "value": ""
         },
         "newWebAppName": {
+            "value": ""
+        },
+        "tenantId": {
+            "value": ""
+        },
+        "existingUserAssignedMSIName": {
+            "value": ""
+        },
+        "existingUserAssignedMSIResourceGroupName": {
             "value": ""
         }
     }

--- a/samples/javascript_nodejs/25.message-reaction/deploymentTemplates/preexisting-rg-parameters.json
+++ b/samples/javascript_nodejs/25.message-reaction/deploymentTemplates/preexisting-rg-parameters.json
@@ -1,0 +1,51 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "appId": {
+            "value": ""
+        },
+        "appSecret": {
+            "value": ""
+        },
+        "appType": {
+            "value": "MultiTenant"
+        },
+        "botId": {
+            "value": ""
+        },
+        "botSku": {
+            "value": ""
+        },
+        "newAppServicePlanName": {
+            "value": ""
+        },
+        "newAppServicePlanSku": {
+            "value": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            }
+        },
+        "appServicePlanLocation": {
+            "value": ""
+        },
+        "existingAppServicePlan": {
+            "value": ""
+        },
+        "newWebAppName": {
+            "value": ""
+        },
+        "tenantId": {
+            "value": ""
+        },
+        "existingUserAssignedMSIName": {
+            "value": ""
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "value": ""
+        }
+    }
+}

--- a/samples/javascript_nodejs/43.complex-dialog/deploymentTemplates/preexisting-rg-parameters.json
+++ b/samples/javascript_nodejs/43.complex-dialog/deploymentTemplates/preexisting-rg-parameters.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "appId": {
@@ -7,6 +7,9 @@
         },
         "appSecret": {
             "value": ""
+        },
+        "appType": {
+            "value": "MultiTenant"
         },
         "botId": {
             "value": ""
@@ -33,6 +36,15 @@
             "value": ""
         },
         "newWebAppName": {
+            "value": ""
+        },
+        "tenantId": {
+            "value": ""
+        },
+        "existingUserAssignedMSIName": {
+            "value": ""
+        },
+        "existingUserAssignedMSIResourceGroupName": {
             "value": ""
         }
     }

--- a/samples/javascript_nodejs/44.prompt-for-user-input/deploymentTemplates/preexisting-rg-parameters.json
+++ b/samples/javascript_nodejs/44.prompt-for-user-input/deploymentTemplates/preexisting-rg-parameters.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "appId": {
@@ -7,6 +7,9 @@
         },
         "appSecret": {
             "value": ""
+        },
+        "appType": {
+            "value": "MultiTenant"
         },
         "botId": {
             "value": ""
@@ -33,6 +36,15 @@
             "value": ""
         },
         "newWebAppName": {
+            "value": ""
+        },
+        "tenantId": {
+            "value": ""
+        },
+        "existingUserAssignedMSIName": {
+            "value": ""
+        },
+        "existingUserAssignedMSIResourceGroupName": {
             "value": ""
         }
     }

--- a/samples/javascript_nodejs/45.state-management/deploymentTemplates/preexisting-rg-parameters.json
+++ b/samples/javascript_nodejs/45.state-management/deploymentTemplates/preexisting-rg-parameters.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "appId": {
@@ -7,6 +7,9 @@
         },
         "appSecret": {
             "value": ""
+        },
+        "appType": {
+            "value": "MultiTenant"
         },
         "botId": {
             "value": ""
@@ -33,6 +36,15 @@
             "value": ""
         },
         "newWebAppName": {
+            "value": ""
+        },
+        "tenantId": {
+            "value": ""
+        },
+        "existingUserAssignedMSIName": {
+            "value": ""
+        },
+        "existingUserAssignedMSIResourceGroupName": {
             "value": ""
         }
     }

--- a/samples/javascript_nodejs/46.teams-auth/deploymentTemplates/preexisting-rg-parameters.json
+++ b/samples/javascript_nodejs/46.teams-auth/deploymentTemplates/preexisting-rg-parameters.json
@@ -1,0 +1,51 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "appId": {
+            "value": ""
+        },
+        "appSecret": {
+            "value": ""
+        },
+        "appType": {
+            "value": "MultiTenant"
+        },
+        "botId": {
+            "value": ""
+        },
+        "botSku": {
+            "value": ""
+        },
+        "newAppServicePlanName": {
+            "value": ""
+        },
+        "newAppServicePlanSku": {
+            "value": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            }
+        },
+        "appServicePlanLocation": {
+            "value": ""
+        },
+        "existingAppServicePlan": {
+            "value": ""
+        },
+        "newWebAppName": {
+            "value": ""
+        },
+        "tenantId": {
+            "value": ""
+        },
+        "existingUserAssignedMSIName": {
+            "value": ""
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "value": ""
+        }
+    }
+}

--- a/samples/javascript_nodejs/47.inspection/deploymentTemplates/preexisting-rg-parameters.json
+++ b/samples/javascript_nodejs/47.inspection/deploymentTemplates/preexisting-rg-parameters.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "appId": {
@@ -7,6 +7,9 @@
         },
         "appSecret": {
             "value": ""
+        },
+        "appType": {
+            "value": "MultiTenant"
         },
         "botId": {
             "value": ""
@@ -33,6 +36,15 @@
             "value": ""
         },
         "newWebAppName": {
+            "value": ""
+        },
+        "tenantId": {
+            "value": ""
+        },
+        "existingUserAssignedMSIName": {
+            "value": ""
+        },
+        "existingUserAssignedMSIResourceGroupName": {
             "value": ""
         }
     }


### PR DESCRIPTION
Addresses # 3536

## Description
This PR updates the JS samples' ARM `preexisting-rg-parameters.json` files to include the parameters required to support MSI.

### Detailed Changes
- Added _appType_, _tenantId_, _existingUserAssignedMSIName_, and _existingUserAssignedMSIResourceGroupName_ to the `preexisting-rg-parameters.json` files.
- Added the missing file in samples _25.message-reaction_ and _46.teams-auth_.

## Testing
This image shows the bots being deployed and tested successfully after the changes.
![image](https://user-images.githubusercontent.com/44245136/139271422-4a050e74-2fc8-464e-9979-9bfaad1da478.png)
