### PR TITLE
[#3536] Add support for MSI to JS samples and generators - ARM new RG templates (2/2)

### DIFF
--- a/generators/generator-botbuilder/generators/app/templates/core/deploymentTemplates/template-with-new-rg.json
+++ b/generators/generator-botbuilder/generators/app/templates/core/deploymentTemplates/template-with-new-rg.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "groupLocation": {
@@ -17,13 +17,26 @@
         "appId": {
             "type": "string",
             "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
         },
         "appSecret": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
             }
         },
         "botId": {
@@ -69,6 +82,27 @@
             "metadata": {
                 "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
         }
     },
     "variables": {
@@ -77,7 +111,35 @@
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
         "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
-        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
+        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -98,7 +160,7 @@
             "properties": {
                 "mode": "Incremental",
                 "template": {
-                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
                     "contentVersion": "1.0.0.0",
                     "parameters": {},
                     "variables": {},
@@ -124,6 +186,7 @@
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
                             ],
                             "name": "[variables('webAppName')]",
+                            "identity": "[variables('appType').identity]",
                             "properties": {
                                 "name": "[variables('webAppName')]",
                                 "serverFarmId": "[variables('appServicePlanName')]",
@@ -134,12 +197,20 @@
                                             "value": "10.14.1"
                                         },
                                         {
+                                            "name": "MicrosoftAppType",
+                                            "value": "[parameters('appType')]"
+                                        },
+                                        {
                                             "name": "MicrosoftAppId",
                                             "value": "[parameters('appId')]"
                                         },
                                         {
                                             "name": "MicrosoftAppPassword",
                                             "value": "[parameters('appSecret')]"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppTenantId",
+                                            "value": "[variables('appType').tenantId]"
                                         }
                                     ],
                                     "cors": {
@@ -166,6 +237,9 @@
                                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
+                                "msaAppTenantId": "[variables('appType').tenantId]",
+                                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                                "msaAppType": "[parameters('appType')]",
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,

--- a/generators/generator-botbuilder/generators/app/templates/echo/deploymentTemplates/template-with-new-rg.json
+++ b/generators/generator-botbuilder/generators/app/templates/echo/deploymentTemplates/template-with-new-rg.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "groupLocation": {
@@ -17,13 +17,26 @@
         "appId": {
             "type": "string",
             "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
         },
         "appSecret": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
             }
         },
         "botId": {
@@ -69,6 +82,27 @@
             "metadata": {
                 "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
         }
     },
     "variables": {
@@ -77,7 +111,35 @@
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
         "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
-        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
+        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -98,7 +160,7 @@
             "properties": {
                 "mode": "Incremental",
                 "template": {
-                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
                     "contentVersion": "1.0.0.0",
                     "parameters": {},
                     "variables": {},
@@ -124,6 +186,7 @@
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
                             ],
                             "name": "[variables('webAppName')]",
+                            "identity": "[variables('appType').identity]",
                             "properties": {
                                 "name": "[variables('webAppName')]",
                                 "serverFarmId": "[variables('appServicePlanName')]",
@@ -134,12 +197,20 @@
                                             "value": "10.14.1"
                                         },
                                         {
+                                            "name": "MicrosoftAppType",
+                                            "value": "[parameters('appType')]"
+                                        },
+                                        {
                                             "name": "MicrosoftAppId",
                                             "value": "[parameters('appId')]"
                                         },
                                         {
                                             "name": "MicrosoftAppPassword",
                                             "value": "[parameters('appSecret')]"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppTenantId",
+                                            "value": "[variables('appType').tenantId]"
                                         }
                                     ],
                                     "cors": {
@@ -166,6 +237,9 @@
                                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
+                                "msaAppTenantId": "[variables('appType').tenantId]",
+                                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                                "msaAppType": "[parameters('appType')]",
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,

--- a/generators/generator-botbuilder/generators/app/templates/empty/deploymentTemplates/template-with-new-rg.json
+++ b/generators/generator-botbuilder/generators/app/templates/empty/deploymentTemplates/template-with-new-rg.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "groupLocation": {
@@ -17,13 +17,26 @@
         "appId": {
             "type": "string",
             "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
         },
         "appSecret": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
             }
         },
         "botId": {
@@ -69,6 +82,27 @@
             "metadata": {
                 "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
         }
     },
     "variables": {
@@ -77,7 +111,35 @@
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
         "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
-        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
+        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -98,7 +160,7 @@
             "properties": {
                 "mode": "Incremental",
                 "template": {
-                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
                     "contentVersion": "1.0.0.0",
                     "parameters": {},
                     "variables": {},
@@ -124,6 +186,7 @@
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
                             ],
                             "name": "[variables('webAppName')]",
+                            "identity": "[variables('appType').identity]",
                             "properties": {
                                 "name": "[variables('webAppName')]",
                                 "serverFarmId": "[variables('appServicePlanName')]",
@@ -134,12 +197,20 @@
                                             "value": "10.14.1"
                                         },
                                         {
+                                            "name": "MicrosoftAppType",
+                                            "value": "[parameters('appType')]"
+                                        },
+                                        {
                                             "name": "MicrosoftAppId",
                                             "value": "[parameters('appId')]"
                                         },
                                         {
                                             "name": "MicrosoftAppPassword",
                                             "value": "[parameters('appSecret')]"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppTenantId",
+                                            "value": "[variables('appType').tenantId]"
                                         }
                                     ],
                                     "cors": {
@@ -166,6 +237,9 @@
                                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
+                                "msaAppTenantId": "[variables('appType').tenantId]",
+                                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                                "msaAppType": "[parameters('appType')]",
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,

--- a/samples/javascript_nodejs/46.teams-auth/deploymentTemplates/template-with-new-rg.json
+++ b/samples/javascript_nodejs/46.teams-auth/deploymentTemplates/template-with-new-rg.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "groupLocation": {
@@ -17,13 +17,26 @@
         "appId": {
             "type": "string",
             "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
         },
         "appSecret": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
             }
         },
         "botId": {
@@ -69,6 +82,27 @@
             "metadata": {
                 "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
         }
     },
     "variables": {
@@ -77,7 +111,35 @@
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
         "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
-        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
+        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -98,7 +160,7 @@
             "properties": {
                 "mode": "Incremental",
                 "template": {
-                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
                     "contentVersion": "1.0.0.0",
                     "parameters": {},
                     "variables": {},
@@ -124,6 +186,7 @@
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
                             ],
                             "name": "[variables('webAppName')]",
+                            "identity": "[variables('appType').identity]",
                             "properties": {
                                 "name": "[variables('webAppName')]",
                                 "serverFarmId": "[variables('appServicePlanName')]",
@@ -134,12 +197,20 @@
                                             "value": "10.14.1"
                                         },
                                         {
+                                            "name": "MicrosoftAppType",
+                                            "value": "[parameters('appType')]"
+                                        },
+                                        {
                                             "name": "MicrosoftAppId",
                                             "value": "[parameters('appId')]"
                                         },
                                         {
                                             "name": "MicrosoftAppPassword",
                                             "value": "[parameters('appSecret')]"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppTenantId",
+                                            "value": "[variables('appType').tenantId]"
                                         }
                                     ],
                                     "cors": {
@@ -166,6 +237,9 @@
                                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
+                                "msaAppTenantId": "[variables('appType').tenantId]",
+                                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                                "msaAppType": "[parameters('appType')]",
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,

--- a/samples/javascript_nodejs/47.inspection/deploymentTemplates/template-with-new-rg.json
+++ b/samples/javascript_nodejs/47.inspection/deploymentTemplates/template-with-new-rg.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "groupLocation": {
@@ -17,13 +17,26 @@
         "appId": {
             "type": "string",
             "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
         },
         "appSecret": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
             }
         },
         "botId": {
@@ -69,6 +82,27 @@
             "metadata": {
                 "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
         }
     },
     "variables": {
@@ -77,7 +111,35 @@
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
         "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
-        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
+        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -98,7 +160,7 @@
             "properties": {
                 "mode": "Incremental",
                 "template": {
-                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
                     "contentVersion": "1.0.0.0",
                     "parameters": {},
                     "variables": {},
@@ -124,6 +186,7 @@
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
                             ],
                             "name": "[variables('webAppName')]",
+                            "identity": "[variables('appType').identity]",
                             "properties": {
                                 "name": "[variables('webAppName')]",
                                 "serverFarmId": "[variables('appServicePlanName')]",
@@ -134,12 +197,20 @@
                                             "value": "10.14.1"
                                         },
                                         {
+                                            "name": "MicrosoftAppType",
+                                            "value": "[parameters('appType')]"
+                                        },
+                                        {
                                             "name": "MicrosoftAppId",
                                             "value": "[parameters('appId')]"
                                         },
                                         {
                                             "name": "MicrosoftAppPassword",
                                             "value": "[parameters('appSecret')]"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppTenantId",
+                                            "value": "[variables('appType').tenantId]"
                                         }
                                     ],
                                     "cors": {
@@ -166,6 +237,9 @@
                                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
+                                "msaAppTenantId": "[variables('appType').tenantId]",
+                                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                                "msaAppType": "[parameters('appType')]",
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,

--- a/samples/javascript_nodejs/49.qnamaker-all-features/deploymentTemplates/template-with-new-rg.json
+++ b/samples/javascript_nodejs/49.qnamaker-all-features/deploymentTemplates/template-with-new-rg.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "groupLocation": {
@@ -17,13 +17,26 @@
         "appId": {
             "type": "string",
             "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
         },
         "appSecret": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
             }
         },
         "botId": {
@@ -69,6 +82,27 @@
             "metadata": {
                 "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
         }
     },
     "variables": {
@@ -77,7 +111,35 @@
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
         "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
-        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
+        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -98,7 +160,7 @@
             "properties": {
                 "mode": "Incremental",
                 "template": {
-                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
                     "contentVersion": "1.0.0.0",
                     "parameters": {},
                     "variables": {},
@@ -124,6 +186,7 @@
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
                             ],
                             "name": "[variables('webAppName')]",
+                            "identity": "[variables('appType').identity]",
                             "properties": {
                                 "name": "[variables('webAppName')]",
                                 "serverFarmId": "[variables('appServicePlanName')]",
@@ -134,12 +197,20 @@
                                             "value": "10.14.1"
                                         },
                                         {
+                                            "name": "MicrosoftAppType",
+                                            "value": "[parameters('appType')]"
+                                        },
+                                        {
                                             "name": "MicrosoftAppId",
                                             "value": "[parameters('appId')]"
                                         },
                                         {
                                             "name": "MicrosoftAppPassword",
                                             "value": "[parameters('appSecret')]"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppTenantId",
+                                            "value": "[variables('appType').tenantId]"
                                         }
                                     ],
                                     "cors": {
@@ -166,6 +237,9 @@
                                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
+                                "msaAppTenantId": "[variables('appType').tenantId]",
+                                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                                "msaAppType": "[parameters('appType')]",
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,

--- a/samples/javascript_nodejs/50.teams-messaging-extensions-search/deploymentTemplates/template-with-new-rg.json
+++ b/samples/javascript_nodejs/50.teams-messaging-extensions-search/deploymentTemplates/template-with-new-rg.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "groupLocation": {
@@ -17,13 +17,26 @@
         "appId": {
             "type": "string",
             "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
         },
         "appSecret": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
             }
         },
         "botId": {
@@ -69,6 +82,27 @@
             "metadata": {
                 "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
         }
     },
     "variables": {
@@ -77,7 +111,35 @@
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
         "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
-        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
+        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -98,7 +160,7 @@
             "properties": {
                 "mode": "Incremental",
                 "template": {
-                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
                     "contentVersion": "1.0.0.0",
                     "parameters": {},
                     "variables": {},
@@ -124,6 +186,7 @@
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
                             ],
                             "name": "[variables('webAppName')]",
+                            "identity": "[variables('appType').identity]",
                             "properties": {
                                 "name": "[variables('webAppName')]",
                                 "serverFarmId": "[variables('appServicePlanName')]",
@@ -134,12 +197,20 @@
                                             "value": "10.14.1"
                                         },
                                         {
+                                            "name": "MicrosoftAppType",
+                                            "value": "[parameters('appType')]"
+                                        },
+                                        {
                                             "name": "MicrosoftAppId",
                                             "value": "[parameters('appId')]"
                                         },
                                         {
                                             "name": "MicrosoftAppPassword",
                                             "value": "[parameters('appSecret')]"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppTenantId",
+                                            "value": "[variables('appType').tenantId]"
                                         }
                                     ],
                                     "cors": {
@@ -166,6 +237,9 @@
                                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
+                                "msaAppTenantId": "[variables('appType').tenantId]",
+                                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                                "msaAppType": "[parameters('appType')]",
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,

--- a/samples/javascript_nodejs/51.teams-messaging-extensions-action/deploymentTemplates/template-with-new-rg.json
+++ b/samples/javascript_nodejs/51.teams-messaging-extensions-action/deploymentTemplates/template-with-new-rg.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "groupLocation": {
@@ -17,13 +17,26 @@
         "appId": {
             "type": "string",
             "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
         },
         "appSecret": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
             }
         },
         "botId": {
@@ -69,6 +82,27 @@
             "metadata": {
                 "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
         }
     },
     "variables": {
@@ -77,7 +111,35 @@
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
         "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
-        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
+        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -98,7 +160,7 @@
             "properties": {
                 "mode": "Incremental",
                 "template": {
-                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
                     "contentVersion": "1.0.0.0",
                     "parameters": {},
                     "variables": {},
@@ -124,6 +186,7 @@
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
                             ],
                             "name": "[variables('webAppName')]",
+                            "identity": "[variables('appType').identity]",
                             "properties": {
                                 "name": "[variables('webAppName')]",
                                 "serverFarmId": "[variables('appServicePlanName')]",
@@ -134,12 +197,20 @@
                                             "value": "10.14.1"
                                         },
                                         {
+                                            "name": "MicrosoftAppType",
+                                            "value": "[parameters('appType')]"
+                                        },
+                                        {
                                             "name": "MicrosoftAppId",
                                             "value": "[parameters('appId')]"
                                         },
                                         {
                                             "name": "MicrosoftAppPassword",
                                             "value": "[parameters('appSecret')]"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppTenantId",
+                                            "value": "[variables('appType').tenantId]"
                                         }
                                     ],
                                     "cors": {
@@ -166,6 +237,9 @@
                                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
+                                "msaAppTenantId": "[variables('appType').tenantId]",
+                                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                                "msaAppType": "[parameters('appType')]",
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,

--- a/samples/javascript_nodejs/52.teams-messaging-extensions-search-auth-config/deploymentTemplates/template-with-new-rg.json
+++ b/samples/javascript_nodejs/52.teams-messaging-extensions-search-auth-config/deploymentTemplates/template-with-new-rg.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "groupLocation": {
@@ -17,13 +17,26 @@
         "appId": {
             "type": "string",
             "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
         },
         "appSecret": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
             }
         },
         "botId": {
@@ -69,6 +82,27 @@
             "metadata": {
                 "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
         }
     },
     "variables": {
@@ -77,7 +111,35 @@
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
         "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
-        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
+        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -98,7 +160,7 @@
             "properties": {
                 "mode": "Incremental",
                 "template": {
-                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
                     "contentVersion": "1.0.0.0",
                     "parameters": {},
                     "variables": {},
@@ -124,6 +186,7 @@
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
                             ],
                             "name": "[variables('webAppName')]",
+                            "identity": "[variables('appType').identity]",
                             "properties": {
                                 "name": "[variables('webAppName')]",
                                 "serverFarmId": "[variables('appServicePlanName')]",
@@ -134,12 +197,20 @@
                                             "value": "10.14.1"
                                         },
                                         {
+                                            "name": "MicrosoftAppType",
+                                            "value": "[parameters('appType')]"
+                                        },
+                                        {
                                             "name": "MicrosoftAppId",
                                             "value": "[parameters('appId')]"
                                         },
                                         {
                                             "name": "MicrosoftAppPassword",
                                             "value": "[parameters('appSecret')]"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppTenantId",
+                                            "value": "[variables('appType').tenantId]"
                                         }
                                     ],
                                     "cors": {
@@ -166,6 +237,9 @@
                                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
+                                "msaAppTenantId": "[variables('appType').tenantId]",
+                                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                                "msaAppType": "[parameters('appType')]",
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,

--- a/samples/javascript_nodejs/53.teams-messaging-extensions-action-preview/deploymentTemplates/template-with-new-rg.json
+++ b/samples/javascript_nodejs/53.teams-messaging-extensions-action-preview/deploymentTemplates/template-with-new-rg.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "groupLocation": {
@@ -17,13 +17,26 @@
         "appId": {
             "type": "string",
             "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
         },
         "appSecret": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
             }
         },
         "botId": {
@@ -69,6 +82,27 @@
             "metadata": {
                 "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
         }
     },
     "variables": {
@@ -77,7 +111,35 @@
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
         "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
-        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
+        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -98,7 +160,7 @@
             "properties": {
                 "mode": "Incremental",
                 "template": {
-                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
                     "contentVersion": "1.0.0.0",
                     "parameters": {},
                     "variables": {},
@@ -124,6 +186,7 @@
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
                             ],
                             "name": "[variables('webAppName')]",
+                            "identity": "[variables('appType').identity]",
                             "properties": {
                                 "name": "[variables('webAppName')]",
                                 "serverFarmId": "[variables('appServicePlanName')]",
@@ -134,12 +197,20 @@
                                             "value": "10.14.1"
                                         },
                                         {
+                                            "name": "MicrosoftAppType",
+                                            "value": "[parameters('appType')]"
+                                        },
+                                        {
                                             "name": "MicrosoftAppId",
                                             "value": "[parameters('appId')]"
                                         },
                                         {
                                             "name": "MicrosoftAppPassword",
                                             "value": "[parameters('appSecret')]"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppTenantId",
+                                            "value": "[variables('appType').tenantId]"
                                         }
                                     ],
                                     "cors": {
@@ -166,6 +237,9 @@
                                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
+                                "msaAppTenantId": "[variables('appType').tenantId]",
+                                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                                "msaAppType": "[parameters('appType')]",
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,

--- a/samples/javascript_nodejs/54.teams-task-module/deploymentTemplates/template-with-new-rg.json
+++ b/samples/javascript_nodejs/54.teams-task-module/deploymentTemplates/template-with-new-rg.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "groupLocation": {
@@ -17,13 +17,26 @@
         "appId": {
             "type": "string",
             "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
         },
         "appSecret": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
             }
         },
         "botId": {
@@ -69,6 +82,27 @@
             "metadata": {
                 "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
         }
     },
     "variables": {
@@ -77,7 +111,35 @@
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
         "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
-        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
+        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -98,7 +160,7 @@
             "properties": {
                 "mode": "Incremental",
                 "template": {
-                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
                     "contentVersion": "1.0.0.0",
                     "parameters": {},
                     "variables": {},
@@ -124,6 +186,7 @@
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
                             ],
                             "name": "[variables('webAppName')]",
+                            "identity": "[variables('appType').identity]",
                             "properties": {
                                 "name": "[variables('webAppName')]",
                                 "serverFarmId": "[variables('appServicePlanName')]",
@@ -134,12 +197,20 @@
                                             "value": "10.14.1"
                                         },
                                         {
+                                            "name": "MicrosoftAppType",
+                                            "value": "[parameters('appType')]"
+                                        },
+                                        {
                                             "name": "MicrosoftAppId",
                                             "value": "[parameters('appId')]"
                                         },
                                         {
                                             "name": "MicrosoftAppPassword",
                                             "value": "[parameters('appSecret')]"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppTenantId",
+                                            "value": "[variables('appType').tenantId]"
                                         }
                                     ],
                                     "cors": {
@@ -166,6 +237,9 @@
                                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
+                                "msaAppTenantId": "[variables('appType').tenantId]",
+                                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                                "msaAppType": "[parameters('appType')]",
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,

--- a/samples/javascript_nodejs/55.teams-link-unfurling/deploymentTemplates/template-with-new-rg.json
+++ b/samples/javascript_nodejs/55.teams-link-unfurling/deploymentTemplates/template-with-new-rg.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "groupLocation": {
@@ -17,13 +17,26 @@
         "appId": {
             "type": "string",
             "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
         },
         "appSecret": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
             }
         },
         "botId": {
@@ -69,6 +82,27 @@
             "metadata": {
                 "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
         }
     },
     "variables": {
@@ -77,7 +111,35 @@
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
         "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
-        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
+        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -98,7 +160,7 @@
             "properties": {
                 "mode": "Incremental",
                 "template": {
-                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
                     "contentVersion": "1.0.0.0",
                     "parameters": {},
                     "variables": {},
@@ -124,6 +186,7 @@
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
                             ],
                             "name": "[variables('webAppName')]",
+                            "identity": "[variables('appType').identity]",
                             "properties": {
                                 "name": "[variables('webAppName')]",
                                 "serverFarmId": "[variables('appServicePlanName')]",
@@ -134,12 +197,20 @@
                                             "value": "10.14.1"
                                         },
                                         {
+                                            "name": "MicrosoftAppType",
+                                            "value": "[parameters('appType')]"
+                                        },
+                                        {
                                             "name": "MicrosoftAppId",
                                             "value": "[parameters('appId')]"
                                         },
                                         {
                                             "name": "MicrosoftAppPassword",
                                             "value": "[parameters('appSecret')]"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppTenantId",
+                                            "value": "[variables('appType').tenantId]"
                                         }
                                     ],
                                     "cors": {
@@ -166,6 +237,9 @@
                                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
+                                "msaAppTenantId": "[variables('appType').tenantId]",
+                                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                                "msaAppType": "[parameters('appType')]",
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,

--- a/samples/javascript_nodejs/56.teams-file-upload/deploymentTemplates/template-with-new-rg.json
+++ b/samples/javascript_nodejs/56.teams-file-upload/deploymentTemplates/template-with-new-rg.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "groupLocation": {
@@ -17,13 +17,26 @@
         "appId": {
             "type": "string",
             "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
         },
         "appSecret": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
             }
         },
         "botId": {
@@ -69,6 +82,27 @@
             "metadata": {
                 "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
         }
     },
     "variables": {
@@ -77,7 +111,35 @@
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
         "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
-        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
+        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -98,7 +160,7 @@
             "properties": {
                 "mode": "Incremental",
                 "template": {
-                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
                     "contentVersion": "1.0.0.0",
                     "parameters": {},
                     "variables": {},
@@ -124,6 +186,7 @@
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
                             ],
                             "name": "[variables('webAppName')]",
+                            "identity": "[variables('appType').identity]",
                             "properties": {
                                 "name": "[variables('webAppName')]",
                                 "serverFarmId": "[variables('appServicePlanName')]",
@@ -134,12 +197,20 @@
                                             "value": "10.14.1"
                                         },
                                         {
+                                            "name": "MicrosoftAppType",
+                                            "value": "[parameters('appType')]"
+                                        },
+                                        {
                                             "name": "MicrosoftAppId",
                                             "value": "[parameters('appId')]"
                                         },
                                         {
                                             "name": "MicrosoftAppPassword",
                                             "value": "[parameters('appSecret')]"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppTenantId",
+                                            "value": "[variables('appType').tenantId]"
                                         }
                                     ],
                                     "cors": {
@@ -166,6 +237,9 @@
                                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
+                                "msaAppTenantId": "[variables('appType').tenantId]",
+                                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                                "msaAppType": "[parameters('appType')]",
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,

--- a/samples/javascript_nodejs/57.teams-conversation-bot/deploymentTemplates/template-with-new-rg.json
+++ b/samples/javascript_nodejs/57.teams-conversation-bot/deploymentTemplates/template-with-new-rg.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "groupLocation": {
@@ -17,13 +17,26 @@
         "appId": {
             "type": "string",
             "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
         },
         "appSecret": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
             }
         },
         "botId": {
@@ -69,6 +82,27 @@
             "metadata": {
                 "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
         }
     },
     "variables": {
@@ -77,7 +111,35 @@
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
         "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
-        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
+        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -98,7 +160,7 @@
             "properties": {
                 "mode": "Incremental",
                 "template": {
-                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
                     "contentVersion": "1.0.0.0",
                     "parameters": {},
                     "variables": {},
@@ -124,6 +186,7 @@
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
                             ],
                             "name": "[variables('webAppName')]",
+                            "identity": "[variables('appType').identity]",
                             "properties": {
                                 "name": "[variables('webAppName')]",
                                 "serverFarmId": "[variables('appServicePlanName')]",
@@ -134,12 +197,20 @@
                                             "value": "10.14.1"
                                         },
                                         {
+                                            "name": "MicrosoftAppType",
+                                            "value": "[parameters('appType')]"
+                                        },
+                                        {
                                             "name": "MicrosoftAppId",
                                             "value": "[parameters('appId')]"
                                         },
                                         {
                                             "name": "MicrosoftAppPassword",
                                             "value": "[parameters('appSecret')]"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppTenantId",
+                                            "value": "[variables('appType').tenantId]"
                                         }
                                     ],
                                     "cors": {
@@ -166,6 +237,9 @@
                                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
+                                "msaAppTenantId": "[variables('appType').tenantId]",
+                                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                                "msaAppType": "[parameters('appType')]",
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,

--- a/samples/javascript_nodejs/58.teams-start-new-thread-in-channel/deploymentTemplates/template-with-new-rg.json
+++ b/samples/javascript_nodejs/58.teams-start-new-thread-in-channel/deploymentTemplates/template-with-new-rg.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "groupLocation": {
@@ -17,13 +17,26 @@
         "appId": {
             "type": "string",
             "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
         },
         "appSecret": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
             }
         },
         "botId": {
@@ -69,6 +82,27 @@
             "metadata": {
                 "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
         }
     },
     "variables": {
@@ -77,7 +111,35 @@
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
         "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
-        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
+        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -98,7 +160,7 @@
             "properties": {
                 "mode": "Incremental",
                 "template": {
-                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
                     "contentVersion": "1.0.0.0",
                     "parameters": {},
                     "variables": {},
@@ -124,6 +186,7 @@
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
                             ],
                             "name": "[variables('webAppName')]",
+                            "identity": "[variables('appType').identity]",
                             "properties": {
                                 "name": "[variables('webAppName')]",
                                 "serverFarmId": "[variables('appServicePlanName')]",
@@ -134,12 +197,20 @@
                                             "value": "10.14.1"
                                         },
                                         {
+                                            "name": "MicrosoftAppType",
+                                            "value": "[parameters('appType')]"
+                                        },
+                                        {
                                             "name": "MicrosoftAppId",
                                             "value": "[parameters('appId')]"
                                         },
                                         {
                                             "name": "MicrosoftAppPassword",
                                             "value": "[parameters('appSecret')]"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppTenantId",
+                                            "value": "[variables('appType').tenantId]"
                                         }
                                     ],
                                     "cors": {
@@ -166,6 +237,9 @@
                                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
+                                "msaAppTenantId": "[variables('appType').tenantId]",
+                                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                                "msaAppType": "[parameters('appType')]",
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,

--- a/samples/javascript_nodejs/80.skills-simple-bot-to-bot/echo-skill-bot/deploymentTemplates/template-with-new-rg.json
+++ b/samples/javascript_nodejs/80.skills-simple-bot-to-bot/echo-skill-bot/deploymentTemplates/template-with-new-rg.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "groupLocation": {
@@ -17,13 +17,26 @@
         "appId": {
             "type": "string",
             "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
         },
         "appSecret": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
             }
         },
         "botId": {
@@ -69,6 +82,27 @@
             "metadata": {
                 "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
         }
     },
     "variables": {
@@ -77,7 +111,35 @@
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
         "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
-        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
+        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -98,7 +160,7 @@
             "properties": {
                 "mode": "Incremental",
                 "template": {
-                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
                     "contentVersion": "1.0.0.0",
                     "parameters": {},
                     "variables": {},
@@ -124,6 +186,7 @@
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
                             ],
                             "name": "[variables('webAppName')]",
+                            "identity": "[variables('appType').identity]",
                             "properties": {
                                 "name": "[variables('webAppName')]",
                                 "serverFarmId": "[variables('appServicePlanName')]",
@@ -134,12 +197,20 @@
                                             "value": "10.14.1"
                                         },
                                         {
+                                            "name": "MicrosoftAppType",
+                                            "value": "[parameters('appType')]"
+                                        },
+                                        {
                                             "name": "MicrosoftAppId",
                                             "value": "[parameters('appId')]"
                                         },
                                         {
                                             "name": "MicrosoftAppPassword",
                                             "value": "[parameters('appSecret')]"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppTenantId",
+                                            "value": "[variables('appType').tenantId]"
                                         }
                                     ],
                                     "cors": {
@@ -166,6 +237,9 @@
                                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
+                                "msaAppTenantId": "[variables('appType').tenantId]",
+                                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                                "msaAppType": "[parameters('appType')]",
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,

--- a/samples/javascript_nodejs/80.skills-simple-bot-to-bot/simple-root-bot/deploymentTemplates/template-with-new-rg.json
+++ b/samples/javascript_nodejs/80.skills-simple-bot-to-bot/simple-root-bot/deploymentTemplates/template-with-new-rg.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "groupLocation": {
@@ -17,13 +17,26 @@
         "appId": {
             "type": "string",
             "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
         },
         "appSecret": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
             }
         },
         "botId": {
@@ -69,6 +82,27 @@
             "metadata": {
                 "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
         }
     },
     "variables": {
@@ -77,7 +111,35 @@
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
         "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
-        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
+        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -98,7 +160,7 @@
             "properties": {
                 "mode": "Incremental",
                 "template": {
-                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
                     "contentVersion": "1.0.0.0",
                     "parameters": {},
                     "variables": {},
@@ -124,6 +186,7 @@
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
                             ],
                             "name": "[variables('webAppName')]",
+                            "identity": "[variables('appType').identity]",
                             "properties": {
                                 "name": "[variables('webAppName')]",
                                 "serverFarmId": "[variables('appServicePlanName')]",
@@ -134,12 +197,20 @@
                                             "value": "10.14.1"
                                         },
                                         {
+                                            "name": "MicrosoftAppType",
+                                            "value": "[parameters('appType')]"
+                                        },
+                                        {
                                             "name": "MicrosoftAppId",
                                             "value": "[parameters('appId')]"
                                         },
                                         {
                                             "name": "MicrosoftAppPassword",
                                             "value": "[parameters('appSecret')]"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppTenantId",
+                                            "value": "[variables('appType').tenantId]"
                                         }
                                     ],
                                     "cors": {
@@ -166,6 +237,9 @@
                                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
+                                "msaAppTenantId": "[variables('appType').tenantId]",
+                                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                                "msaAppType": "[parameters('appType')]",
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,

--- a/samples/javascript_nodejs/81.skills-skilldialog/dialogRootBot/deploymentTemplates/template-with-new-rg.json
+++ b/samples/javascript_nodejs/81.skills-skilldialog/dialogRootBot/deploymentTemplates/template-with-new-rg.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "groupLocation": {
@@ -17,13 +17,26 @@
         "appId": {
             "type": "string",
             "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
         },
         "appSecret": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
             }
         },
         "botId": {
@@ -69,6 +82,27 @@
             "metadata": {
                 "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
         }
     },
     "variables": {
@@ -77,7 +111,35 @@
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
         "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
-        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
+        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -98,7 +160,7 @@
             "properties": {
                 "mode": "Incremental",
                 "template": {
-                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
                     "contentVersion": "1.0.0.0",
                     "parameters": {},
                     "variables": {},
@@ -124,6 +186,7 @@
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
                             ],
                             "name": "[variables('webAppName')]",
+                            "identity": "[variables('appType').identity]",
                             "properties": {
                                 "name": "[variables('webAppName')]",
                                 "serverFarmId": "[variables('appServicePlanName')]",
@@ -134,12 +197,20 @@
                                             "value": "10.14.1"
                                         },
                                         {
+                                            "name": "MicrosoftAppType",
+                                            "value": "[parameters('appType')]"
+                                        },
+                                        {
                                             "name": "MicrosoftAppId",
                                             "value": "[parameters('appId')]"
                                         },
                                         {
                                             "name": "MicrosoftAppPassword",
                                             "value": "[parameters('appSecret')]"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppTenantId",
+                                            "value": "[variables('appType').tenantId]"
                                         }
                                     ],
                                     "cors": {
@@ -166,6 +237,9 @@
                                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
+                                "msaAppTenantId": "[variables('appType').tenantId]",
+                                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                                "msaAppType": "[parameters('appType')]",
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,

--- a/samples/javascript_nodejs/81.skills-skilldialog/dialogSkillBot/deploymentTemplates/template-with-new-rg.json
+++ b/samples/javascript_nodejs/81.skills-skilldialog/dialogSkillBot/deploymentTemplates/template-with-new-rg.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "groupLocation": {
@@ -17,13 +17,26 @@
         "appId": {
             "type": "string",
             "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
         },
         "appSecret": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
             }
         },
         "botId": {
@@ -69,6 +82,27 @@
             "metadata": {
                 "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
         }
     },
     "variables": {
@@ -77,7 +111,35 @@
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
         "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
-        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
+        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -98,7 +160,7 @@
             "properties": {
                 "mode": "Incremental",
                 "template": {
-                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
                     "contentVersion": "1.0.0.0",
                     "parameters": {},
                     "variables": {},
@@ -124,6 +186,7 @@
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
                             ],
                             "name": "[variables('webAppName')]",
+                            "identity": "[variables('appType').identity]",
                             "properties": {
                                 "name": "[variables('webAppName')]",
                                 "serverFarmId": "[variables('appServicePlanName')]",
@@ -134,12 +197,20 @@
                                             "value": "10.14.1"
                                         },
                                         {
+                                            "name": "MicrosoftAppType",
+                                            "value": "[parameters('appType')]"
+                                        },
+                                        {
                                             "name": "MicrosoftAppId",
                                             "value": "[parameters('appId')]"
                                         },
                                         {
                                             "name": "MicrosoftAppPassword",
                                             "value": "[parameters('appSecret')]"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppTenantId",
+                                            "value": "[variables('appType').tenantId]"
                                         }
                                     ],
                                     "cors": {
@@ -166,6 +237,9 @@
                                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
+                                "msaAppTenantId": "[variables('appType').tenantId]",
+                                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                                "msaAppType": "[parameters('appType')]",
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,

--- a/samples/javascript_nodejs/language-generation/05.a.multi-turn-prompt-with-language-fallback/deploymentTemplates/template-with-new-rg.json
+++ b/samples/javascript_nodejs/language-generation/05.a.multi-turn-prompt-with-language-fallback/deploymentTemplates/template-with-new-rg.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "groupLocation": {
@@ -17,13 +17,26 @@
         "appId": {
             "type": "string",
             "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
         },
         "appSecret": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
             }
         },
         "botId": {
@@ -69,6 +82,27 @@
             "metadata": {
                 "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
         }
     },
     "variables": {
@@ -77,7 +111,35 @@
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
         "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
-        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
+        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -98,7 +160,7 @@
             "properties": {
                 "mode": "Incremental",
                 "template": {
-                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
                     "contentVersion": "1.0.0.0",
                     "parameters": {},
                     "variables": {},
@@ -124,6 +186,7 @@
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
                             ],
                             "name": "[variables('webAppName')]",
+                            "identity": "[variables('appType').identity]",
                             "properties": {
                                 "name": "[variables('webAppName')]",
                                 "serverFarmId": "[variables('appServicePlanName')]",
@@ -134,12 +197,20 @@
                                             "value": "10.14.1"
                                         },
                                         {
+                                            "name": "MicrosoftAppType",
+                                            "value": "[parameters('appType')]"
+                                        },
+                                        {
                                             "name": "MicrosoftAppId",
                                             "value": "[parameters('appId')]"
                                         },
                                         {
                                             "name": "MicrosoftAppPassword",
                                             "value": "[parameters('appSecret')]"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppTenantId",
+                                            "value": "[variables('appType').tenantId]"
                                         }
                                     ],
                                     "cors": {
@@ -166,6 +237,9 @@
                                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
+                                "msaAppTenantId": "[variables('appType').tenantId]",
+                                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                                "msaAppType": "[parameters('appType')]",
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,

--- a/samples/javascript_nodejs/language-generation/05.multi-turn-prompt/deploymentTemplates/template-with-new-rg.json
+++ b/samples/javascript_nodejs/language-generation/05.multi-turn-prompt/deploymentTemplates/template-with-new-rg.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "groupLocation": {
@@ -17,13 +17,26 @@
         "appId": {
             "type": "string",
             "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
         },
         "appSecret": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
             }
         },
         "botId": {
@@ -69,6 +82,27 @@
             "metadata": {
                 "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
         }
     },
     "variables": {
@@ -77,7 +111,35 @@
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
         "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
-        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
+        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -98,7 +160,7 @@
             "properties": {
                 "mode": "Incremental",
                 "template": {
-                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
                     "contentVersion": "1.0.0.0",
                     "parameters": {},
                     "variables": {},
@@ -124,6 +186,7 @@
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
                             ],
                             "name": "[variables('webAppName')]",
+                            "identity": "[variables('appType').identity]",
                             "properties": {
                                 "name": "[variables('webAppName')]",
                                 "serverFarmId": "[variables('appServicePlanName')]",
@@ -134,12 +197,20 @@
                                             "value": "10.14.1"
                                         },
                                         {
+                                            "name": "MicrosoftAppType",
+                                            "value": "[parameters('appType')]"
+                                        },
+                                        {
                                             "name": "MicrosoftAppId",
                                             "value": "[parameters('appId')]"
                                         },
                                         {
                                             "name": "MicrosoftAppPassword",
                                             "value": "[parameters('appSecret')]"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppTenantId",
+                                            "value": "[variables('appType').tenantId]"
                                         }
                                     ],
                                     "cors": {
@@ -166,6 +237,9 @@
                                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
+                                "msaAppTenantId": "[variables('appType').tenantId]",
+                                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                                "msaAppType": "[parameters('appType')]",
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,

--- a/samples/javascript_nodejs/language-generation/06.using-cards/deploymentTemplates/template-with-new-rg.json
+++ b/samples/javascript_nodejs/language-generation/06.using-cards/deploymentTemplates/template-with-new-rg.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "groupLocation": {
@@ -17,13 +17,26 @@
         "appId": {
             "type": "string",
             "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
         },
         "appSecret": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
             }
         },
         "botId": {
@@ -69,6 +82,27 @@
             "metadata": {
                 "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
         }
     },
     "variables": {
@@ -77,7 +111,35 @@
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
         "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
-        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
+        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -98,7 +160,7 @@
             "properties": {
                 "mode": "Incremental",
                 "template": {
-                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
                     "contentVersion": "1.0.0.0",
                     "parameters": {},
                     "variables": {},
@@ -124,6 +186,7 @@
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
                             ],
                             "name": "[variables('webAppName')]",
+                            "identity": "[variables('appType').identity]",
                             "properties": {
                                 "name": "[variables('webAppName')]",
                                 "serverFarmId": "[variables('appServicePlanName')]",
@@ -134,12 +197,20 @@
                                             "value": "10.14.1"
                                         },
                                         {
+                                            "name": "MicrosoftAppType",
+                                            "value": "[parameters('appType')]"
+                                        },
+                                        {
                                             "name": "MicrosoftAppId",
                                             "value": "[parameters('appId')]"
                                         },
                                         {
                                             "name": "MicrosoftAppPassword",
                                             "value": "[parameters('appSecret')]"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppTenantId",
+                                            "value": "[variables('appType').tenantId]"
                                         }
                                     ],
                                     "cors": {
@@ -166,6 +237,9 @@
                                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
+                                "msaAppTenantId": "[variables('appType').tenantId]",
+                                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                                "msaAppType": "[parameters('appType')]",
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,

--- a/samples/javascript_nodejs/language-generation/13.core-bot/deploymentTemplates/template-with-new-rg.json
+++ b/samples/javascript_nodejs/language-generation/13.core-bot/deploymentTemplates/template-with-new-rg.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "groupLocation": {
@@ -17,13 +17,26 @@
         "appId": {
             "type": "string",
             "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
         },
         "appSecret": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
             }
         },
         "botId": {
@@ -69,6 +82,27 @@
             "metadata": {
                 "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
         }
     },
     "variables": {
@@ -77,7 +111,35 @@
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
         "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
-        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
+        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -98,7 +160,7 @@
             "properties": {
                 "mode": "Incremental",
                 "template": {
-                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
                     "contentVersion": "1.0.0.0",
                     "parameters": {},
                     "variables": {},
@@ -124,6 +186,7 @@
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
                             ],
                             "name": "[variables('webAppName')]",
+                            "identity": "[variables('appType').identity]",
                             "properties": {
                                 "name": "[variables('webAppName')]",
                                 "serverFarmId": "[variables('appServicePlanName')]",
@@ -134,12 +197,20 @@
                                             "value": "10.14.1"
                                         },
                                         {
+                                            "name": "MicrosoftAppType",
+                                            "value": "[parameters('appType')]"
+                                        },
+                                        {
                                             "name": "MicrosoftAppId",
                                             "value": "[parameters('appId')]"
                                         },
                                         {
                                             "name": "MicrosoftAppPassword",
                                             "value": "[parameters('appSecret')]"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppTenantId",
+                                            "value": "[variables('appType').tenantId]"
                                         }
                                     ],
                                     "cors": {
@@ -166,6 +237,9 @@
                                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
+                                "msaAppTenantId": "[variables('appType').tenantId]",
+                                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                                "msaAppType": "[parameters('appType')]",
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,

--- a/samples/javascript_nodejs/language-generation/20.custom-functions/deploymentTemplates/template-with-new-rg.json
+++ b/samples/javascript_nodejs/language-generation/20.custom-functions/deploymentTemplates/template-with-new-rg.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "groupLocation": {
@@ -17,13 +17,26 @@
         "appId": {
             "type": "string",
             "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
         },
         "appSecret": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
             }
         },
         "botId": {
@@ -69,6 +82,27 @@
             "metadata": {
                 "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
         }
     },
     "variables": {
@@ -77,7 +111,35 @@
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
         "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
-        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
+        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -98,7 +160,7 @@
             "properties": {
                 "mode": "Incremental",
                 "template": {
-                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
                     "contentVersion": "1.0.0.0",
                     "parameters": {},
                     "variables": {},
@@ -124,6 +186,7 @@
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
                             ],
                             "name": "[variables('webAppName')]",
+                            "identity": "[variables('appType').identity]",
                             "properties": {
                                 "name": "[variables('webAppName')]",
                                 "serverFarmId": "[variables('appServicePlanName')]",
@@ -134,12 +197,20 @@
                                             "value": "10.14.1"
                                         },
                                         {
+                                            "name": "MicrosoftAppType",
+                                            "value": "[parameters('appType')]"
+                                        },
+                                        {
                                             "name": "MicrosoftAppId",
                                             "value": "[parameters('appId')]"
                                         },
                                         {
                                             "name": "MicrosoftAppPassword",
                                             "value": "[parameters('appSecret')]"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppTenantId",
+                                            "value": "[variables('appType').tenantId]"
                                         }
                                     ],
                                     "cors": {
@@ -166,6 +237,9 @@
                                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
+                                "msaAppTenantId": "[variables('appType').tenantId]",
+                                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                                "msaAppType": "[parameters('appType')]",
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,


### PR DESCRIPTION
Addresses # 3536

## Description
This PR updates the JS samples' ARM `template-with-new-rg.json` files to include the parameters and resources required to support MSI.

### Detailed Changes
- Added _appType_, _tenantId_, _existingUserAssignedMSIName_, and _existingUserAssignedMSIResourceGroupName_ parameters.
- Added the connection with the provided identity in case MSI app type is selected.

## Testing
This image shows the bots being deployed and tested successfully after the changes.
![image](https://user-images.githubusercontent.com/44245136/138276120-46506387-d942-4b3a-8aad-27e40d8a8877.png)