### PR TITLE
[#3322] Fix all dotnet compiler warnings in BotBuilder-Samples

### DIFF
--- a/samples/csharp_dotnetcore/42.scaleout/ScaleoutBot.csproj
+++ b/samples/csharp_dotnetcore/42.scaleout/ScaleoutBot.csproj
@@ -12,6 +12,21 @@
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.16.0" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <!-- The KeyVault package, picked up as a transitive dependency of the Azure Storage libraries
+        doesn't yet support NetStandard20. I confirmed with the Azure Storage team that this warning
+        is fine, and can be supressed.
+
+        It does appear the Azure SDK team is "in-process" of supporting NetStandard20 as seen in this
+        Commit: https://github.com/Azure/azure-sdk-for-net/commit/b0d42d14bfe92a24996826b2487ba592e644f581
+
+        We cannot apply the no-warn supression directly to the package links below as
+        they're not picked up across transitive dependencies. See this GitHub Issue for details:
+        https://github.com/NuGet/Home/issues/5740
+        -->
+    <NoWarn>$(NoWarn);NU1701</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <Content Update="appsettings.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/samples/csharp_dotnetcore/45.state-management/StateMangementBot.csproj
+++ b/samples/csharp_dotnetcore/45.state-management/StateMangementBot.csproj
@@ -12,6 +12,21 @@
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.16.0" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <!-- The KeyVault package, picked up as a transitive dependency of the Azure Storage libraries
+        doesn't yet support NetStandard20. I confirmed with the Azure Storage team that this warning
+        is fine, and can be supressed.
+
+        It does appear the Azure SDK team is "in-process" of supporting NetStandard20 as seen in this
+        Commit: https://github.com/Azure/azure-sdk-for-net/commit/b0d42d14bfe92a24996826b2487ba592e644f581
+
+        We cannot apply the no-warn supression directly to the package links below as
+        they're not picked up across transitive dependencies. See this GitHub Issue for details:
+        https://github.com/NuGet/Home/issues/5740
+        -->
+    <NoWarn>$(NoWarn);NU1701</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <Content Update="appsettings.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/samples/csharp_dotnetcore/46.teams-auth/TeamsAuth.csproj
+++ b/samples/csharp_dotnetcore/46.teams-auth/TeamsAuth.csproj
@@ -7,7 +7,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Graph" Version="1.21.0" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.16.0" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.16.0" />

--- a/samples/csharp_dotnetcore/47.inspection/AdapterWithInspection.cs
+++ b/samples/csharp_dotnetcore/47.inspection/AdapterWithInspection.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+#pragma warning disable CS0618 // Type or member is obsolete
 
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;

--- a/samples/csharp_dotnetcore/47.inspection/Startup.cs
+++ b/samples/csharp_dotnetcore/47.inspection/Startup.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+#pragma warning disable CS0618 // Type or member is obsolete
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;

--- a/samples/csharp_dotnetcore/48.customQABot-all-features/Startup.cs
+++ b/samples/csharp_dotnetcore/48.customQABot-all-features/Startup.cs
@@ -47,7 +47,7 @@ namespace Microsoft.BotBuilderSamples
 
             // Create the bot as a transient. In this case the ASP Controller is expecting an IBot.
             services.AddTransient<IBot, CustomQABot<RootDialog>>();
-            
+
             new DialogsBotComponent().ConfigureServices(services, Configuration);
         }
 

--- a/samples/csharp_dotnetcore/48.customQABot-all-features/Startup.cs
+++ b/samples/csharp_dotnetcore/48.customQABot-all-features/Startup.cs
@@ -26,7 +26,7 @@ namespace Microsoft.BotBuilderSamples
         public IConfiguration Configuration { get; }
 
         // This method gets called by the runtime. Use this method to add services to the container.
-        public void ConfigureServices(IServiceCollection services, BotComponent botcomponent)
+        public void ConfigureServices(IServiceCollection services)
         {
             services.AddHttpClient().AddControllers().AddNewtonsoftJson();
 
@@ -47,8 +47,8 @@ namespace Microsoft.BotBuilderSamples
 
             // Create the bot as a transient. In this case the ASP Controller is expecting an IBot.
             services.AddTransient<IBot, CustomQABot<RootDialog>>();
-
-            botcomponent.ConfigureServices(services, Configuration);
+            
+            new DialogsBotComponent().ConfigureServices(services, Configuration);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/samples/csharp_dotnetcore/48.customQABot-all-features/Startup.cs
+++ b/samples/csharp_dotnetcore/48.customQABot-all-features/Startup.cs
@@ -10,13 +10,23 @@ using Microsoft.BotBuilderSamples.Bots;
 using Microsoft.BotBuilderSamples.Dialogs;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.BotBuilderSamples
 {
     public class Startup
+
     {
+
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
         // This method gets called by the runtime. Use this method to add services to the container.
-        public void ConfigureServices(IServiceCollection services)
+        public void ConfigureServices(IServiceCollection services, BotComponent botcomponent)
         {
             services.AddHttpClient().AddControllers().AddNewtonsoftJson();
 
@@ -38,7 +48,9 @@ namespace Microsoft.BotBuilderSamples
             // Create the bot as a transient. In this case the ASP Controller is expecting an IBot.
             services.AddTransient<IBot, CustomQABot<RootDialog>>();
 
-            ComponentRegistration.Add(new DialogsComponentRegistration());
+            //ComponentRegistration.Add(new DialogsComponentRegistration());
+
+            botcomponent.ConfigureServices(services, Configuration);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/samples/csharp_dotnetcore/48.customQABot-all-features/Startup.cs
+++ b/samples/csharp_dotnetcore/48.customQABot-all-features/Startup.cs
@@ -48,8 +48,6 @@ namespace Microsoft.BotBuilderSamples
             // Create the bot as a transient. In this case the ASP Controller is expecting an IBot.
             services.AddTransient<IBot, CustomQABot<RootDialog>>();
 
-            //ComponentRegistration.Add(new DialogsComponentRegistration());
-
             botcomponent.ConfigureServices(services, Configuration);
         }
 

--- a/samples/csharp_dotnetcore/49.qnamaker-all-features/Dialog/QnAMakerBaseDialog.cs
+++ b/samples/csharp_dotnetcore/49.qnamaker-all-features/Dialog/QnAMakerBaseDialog.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
 
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder;

--- a/samples/csharp_dotnetcore/49.qnamaker-all-features/Dialog/QnAMakerBaseDialog.cs
+++ b/samples/csharp_dotnetcore/49.qnamaker-all-features/Dialog/QnAMakerBaseDialog.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
 
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder;
@@ -41,7 +40,7 @@ namespace Microsoft.BotBuilderSamples.Dialog
 
         protected async override Task<IQnAMakerClient> GetQnAMakerClientAsync(DialogContext dc)
         {
-            return this._services?.QnAMakerService;
+            return await Task.FromResult(this._services?.QnAMakerService);
         }
 
         protected override Task<QnAMakerOptions> GetQnAMakerOptionsAsync(DialogContext dc)
@@ -70,7 +69,7 @@ namespace Microsoft.BotBuilderSamples.Dialog
                 CardNoMatchResponse = cardNoMatchResponse,
             };
 
-            return responseOptions;
+            return await Task.FromResult(responseOptions);
         }
     }
 }

--- a/samples/csharp_dotnetcore/49.qnamaker-all-features/Startup.cs
+++ b/samples/csharp_dotnetcore/49.qnamaker-all-features/Startup.cs
@@ -25,7 +25,7 @@ namespace Microsoft.BotBuilderSamples
         public IConfiguration Configuration { get; }
 
         // This method gets called by the runtime. Use this method to add services to the container.
-        public void ConfigureServices(IServiceCollection services, BotComponent botcomponent)
+        public void ConfigureServices(IServiceCollection services)
         {
             services.AddHttpClient().AddControllers().AddNewtonsoftJson();
 
@@ -53,7 +53,7 @@ namespace Microsoft.BotBuilderSamples
             // Create the bot as a transient. In this case the ASP Controller is expecting an IBot.
             services.AddTransient<IBot, QnABot<RootDialog>>();
 
-            botcomponent.ConfigureServices(services, Configuration);
+            new DialogsBotComponent().ConfigureServices(services, Configuration);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/samples/csharp_dotnetcore/49.qnamaker-all-features/Startup.cs
+++ b/samples/csharp_dotnetcore/49.qnamaker-all-features/Startup.cs
@@ -25,7 +25,7 @@ namespace Microsoft.BotBuilderSamples
         public IConfiguration Configuration { get; }
 
         // This method gets called by the runtime. Use this method to add services to the container.
-        public void ConfigureServices(IServiceCollection services)
+        public void ConfigureServices(IServiceCollection services, BotComponent botcomponent)
         {
             services.AddHttpClient().AddControllers().AddNewtonsoftJson();
 
@@ -53,7 +53,9 @@ namespace Microsoft.BotBuilderSamples
             // Create the bot as a transient. In this case the ASP Controller is expecting an IBot.
             services.AddTransient<IBot, QnABot<RootDialog>>();
 
-            ComponentRegistration.Add(new DialogsComponentRegistration());
+            //ComponentRegistration.Add(new DialogsComponentRegistration());
+
+            botcomponent.ConfigureServices(services, Configuration);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/samples/csharp_dotnetcore/49.qnamaker-all-features/Startup.cs
+++ b/samples/csharp_dotnetcore/49.qnamaker-all-features/Startup.cs
@@ -53,8 +53,6 @@ namespace Microsoft.BotBuilderSamples
             // Create the bot as a transient. In this case the ASP Controller is expecting an IBot.
             services.AddTransient<IBot, QnABot<RootDialog>>();
 
-            //ComponentRegistration.Add(new DialogsComponentRegistration());
-
             botcomponent.ConfigureServices(services, Configuration);
         }
 

--- a/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/Bots/TeamsMessagingExtensionsActionBot.cs
+++ b/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/Bots/TeamsMessagingExtensionsActionBot.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
 
 using System;
 using System.Collections.Generic;
@@ -44,7 +43,7 @@ namespace Microsoft.BotBuilderSamples.Bots
                 case "razorView":
                     return RazorViewResponse(turnContext, action);
             }
-            return new MessagingExtensionActionResponse();
+            return await Task.FromResult(new MessagingExtensionActionResponse());
         }
 
         private MessagingExtensionActionResponse RazorViewResponse(ITurnContext<IInvokeActivity> turnContext, MessagingExtensionAction action)

--- a/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/Bots/TeamsMessagingExtensionsActionBot.cs
+++ b/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/Bots/TeamsMessagingExtensionsActionBot.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
 
 using System;
 using System.Collections.Generic;

--- a/samples/csharp_dotnetcore/82.skills-sso-cloudadapter/RootBot/TokenExchangeSkillHandler.cs
+++ b/samples/csharp_dotnetcore/82.skills-sso-cloudadapter/RootBot/TokenExchangeSkillHandler.cs
@@ -16,6 +16,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Newtonsoft.Json.Linq;
+using Microsoft.Bot.Builder.Integration.AspNet.Core;
 
 namespace Microsoft.BotBuilderSamples.RootBot
 {
@@ -75,6 +76,7 @@ namespace Microsoft.BotBuilderSamples.RootBot
         private BotFrameworkSkill GetCallingSkill(ClaimsIdentity claimsIdentity)
         {
             var appId = JwtTokenValidation.GetAppIdFromClaims(claimsIdentity.Claims);
+
 
             if (string.IsNullOrWhiteSpace(appId))
             {

--- a/samples/csharp_dotnetcore/82.skills-sso-cloudadapter/RootBot/TokenExchangeSkillHandler.cs
+++ b/samples/csharp_dotnetcore/82.skills-sso-cloudadapter/RootBot/TokenExchangeSkillHandler.cs
@@ -16,7 +16,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Newtonsoft.Json.Linq;
-using Microsoft.Bot.Builder.Integration.AspNet.Core;
 
 namespace Microsoft.BotBuilderSamples.RootBot
 {
@@ -32,7 +31,6 @@ namespace Microsoft.BotBuilderSamples.RootBot
         private readonly SkillConversationIdFactoryBase _conversationIdFactory;
         private readonly ILogger _logger;
         private readonly SkillsConfiguration _skillsConfig;
-        private readonly ConfigurationBotFrameworkAuthentication _configurationBotFrameworkAuthentication;
 
         public TokenExchangeSkillHandler(
             BotAdapter adapter,
@@ -41,7 +39,6 @@ namespace Microsoft.BotBuilderSamples.RootBot
             BotFrameworkAuthentication auth,
             SkillsConfiguration skillsConfiguration,
             IConfiguration configuration,
-            ConfigurationBotFrameworkAuthentication configurationBotFrameworkAuthentication,
             ILogger<TokenExchangeSkillHandler> logger = null)
             : base(adapter, bot, conversationIdFactory, auth, logger)
         {
@@ -53,7 +50,6 @@ namespace Microsoft.BotBuilderSamples.RootBot
             _botId = configuration.GetSection(MicrosoftAppCredentials.MicrosoftAppIdKey)?.Value;
             _connectionName = configuration.GetSection("ConnectionName")?.Value;
             _logger = logger ?? NullLogger<TokenExchangeSkillHandler>.Instance;
-            _configurationBotFrameworkAuthentication = configurationBotFrameworkAuthentication ?? throw new ArgumentNullException(nameof(configurationBotFrameworkAuthentication));
         }
 
         protected override async Task<ResourceResponse> OnSendToConversationAsync(ClaimsIdentity claimsIdentity, string conversationId, Activity activity, CancellationToken cancellationToken = default)
@@ -78,9 +74,8 @@ namespace Microsoft.BotBuilderSamples.RootBot
 
         private BotFrameworkSkill GetCallingSkill(ClaimsIdentity claimsIdentity)
         {
-            var botAppIdClaim = claimsIdentity.Claims?.SingleOrDefault(claim => claim.Type == AuthenticationConstants.AudienceClaim);
-            var appId = botAppIdClaim.Value;
-
+            var botAppIdClaim = claimsIdentity.Claims?.FirstOrDefault(claim => claim.Type == AuthenticationConstants.AppIdClaim);
+            var appId = botAppIdClaim?.Value;
             if (string.IsNullOrWhiteSpace(appId))
             {
                 return null;

--- a/samples/csharp_dotnetcore/82.skills-sso-cloudadapter/RootBot/TokenExchangeSkillHandler.cs
+++ b/samples/csharp_dotnetcore/82.skills-sso-cloudadapter/RootBot/TokenExchangeSkillHandler.cs
@@ -53,6 +53,7 @@ namespace Microsoft.BotBuilderSamples.RootBot
             _botId = configuration.GetSection(MicrosoftAppCredentials.MicrosoftAppIdKey)?.Value;
             _connectionName = configuration.GetSection("ConnectionName")?.Value;
             _logger = logger ?? NullLogger<TokenExchangeSkillHandler>.Instance;
+            _configurationBotFrameworkAuthentication = configurationBotFrameworkAuthentication ?? throw new ArgumentNullException(nameof(configurationBotFrameworkAuthentication));
         }
 
         protected override async Task<ResourceResponse> OnSendToConversationAsync(ClaimsIdentity claimsIdentity, string conversationId, Activity activity, CancellationToken cancellationToken = default)
@@ -77,7 +78,8 @@ namespace Microsoft.BotBuilderSamples.RootBot
 
         private BotFrameworkSkill GetCallingSkill(ClaimsIdentity claimsIdentity)
         {
-            var appId = _configurationBotFrameworkAuthentication.GetOriginatingAudience();
+            var botAppIdClaim = claimsIdentity.Claims?.SingleOrDefault(claim => claim.Type == AuthenticationConstants.AudienceClaim);
+            var appId = botAppIdClaim.Value;
 
             if (string.IsNullOrWhiteSpace(appId))
             {

--- a/samples/csharp_dotnetcore/82.skills-sso-cloudadapter/RootBot/TokenExchangeSkillHandler.cs
+++ b/samples/csharp_dotnetcore/82.skills-sso-cloudadapter/RootBot/TokenExchangeSkillHandler.cs
@@ -32,6 +32,7 @@ namespace Microsoft.BotBuilderSamples.RootBot
         private readonly SkillConversationIdFactoryBase _conversationIdFactory;
         private readonly ILogger _logger;
         private readonly SkillsConfiguration _skillsConfig;
+        private readonly ConfigurationBotFrameworkAuthentication _configurationBotFrameworkAuthentication;
 
         public TokenExchangeSkillHandler(
             BotAdapter adapter,
@@ -40,6 +41,7 @@ namespace Microsoft.BotBuilderSamples.RootBot
             BotFrameworkAuthentication auth,
             SkillsConfiguration skillsConfiguration,
             IConfiguration configuration,
+            ConfigurationBotFrameworkAuthentication configurationBotFrameworkAuthentication,
             ILogger<TokenExchangeSkillHandler> logger = null)
             : base(adapter, bot, conversationIdFactory, auth, logger)
         {
@@ -75,8 +77,7 @@ namespace Microsoft.BotBuilderSamples.RootBot
 
         private BotFrameworkSkill GetCallingSkill(ClaimsIdentity claimsIdentity)
         {
-            var appId = JwtTokenValidation.GetAppIdFromClaims(claimsIdentity.Claims);
-
+            var appId = _configurationBotFrameworkAuthentication.GetOriginatingAudience();
 
             if (string.IsNullOrWhiteSpace(appId))
             {


### PR DESCRIPTION
Addresses # 3322
#minor

## Description
This PR fixes all dotnet compiler warnings in BotBuilder-Samples.

## Specific Changes
Fixed warnings:

- Obsolete related warnings
- Async related warnings
- .NET Framework version related warnings
- Razor language version downgrade warnings


## Testing

Inspection.
![image](https://user-images.githubusercontent.com/64815358/172864516-98022e19-122a-41ac-b0d5-d97fc7f00ffa.png)

StateManagement.
![image](https://user-images.githubusercontent.com/64815358/172864739-c1b1f743-c8ed-4fa9-a682-0e646c911982.png)

Scaleout.
![image](https://user-images.githubusercontent.com/64815358/172863537-6dafcb31-9a7f-40e6-b16c-587a1e0ead24.png)

TeamsAuth.
![image](https://user-images.githubusercontent.com/64815358/172861212-ee28d3d8-8263-46d9-aaef-86ac0543c9d8.png)

TeamsMessagingExtensionsAction.
![image](https://user-images.githubusercontent.com/64815358/172861421-cc362c2a-dba5-45b9-b397-962cbb10aaf7.png)

QnAMaker-All-Features.
![image](https://user-images.githubusercontent.com/64815358/172859999-840b9e58-75e7-4a79-acbb-fef7365fd8ff.png)

Skills-SSO-CloudAdapter.
![image](https://user-images.githubusercontent.com/64815358/172860779-fecf1cb6-18f8-4f7e-af0c-382376873e53.png)
